### PR TITLE
Add Graphene, a GraphQL library for python

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -202,6 +202,13 @@
     "image": "https://raw.githubusercontent.com/apache/groovy-website/asf-site/site/src/site/assets/img/groovy-logo-colored.svg",
     "language": "Groovy"
   },
+  "Graphene": {
+    "imports": ["graphene"],
+    "technologies": ["Web Development", "Python Library"],
+    "description": "GraphQL in Python Made Easy.",
+    "image": "https://avatars2.githubusercontent.com/u/15002022?s=200&v=4",
+    "language": "Python"
+  },
   "Gson": {
     "imports": ["com.google.gson"],
     "technologies": ["JSon"],


### PR DESCRIPTION
Graphene-Python is a library for building GraphQL APIs in Python easily, its main goal is to provide a simple but extendable API for making developers' lives easier.