### PR TITLE
Add GORM

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -195,6 +195,12 @@
     "description": "Go Micro provides the core requirements for distributed systems development including RPC and Event driven communication.",
     "language": "Go"
   },
+  "GORM": {
+    "imports": ["github.com/jinzhu/gorm"],
+    "technologies": ["ORM"],
+    "description": "GORM is a fully-featured ORM library for Golang supporting MySQL, SQLite3, PostgreSQL and Microsoft SQL Server.",
+    "language": "Go"
+  },
   "Grails": {
     "imports": ["grails"],
     "technologies": ["Web Development", "Java Frameworks"],
@@ -329,7 +335,7 @@
     "imports": ["org.mockito"],
     "technologies": ["Testing"],
     "description": "Mocking framework for unit tests in Java",
-    "image": "https://raw.githubusercontent.com/mockito/mockito.github.io/master/img/logo%402x.png", 
+    "image": "https://raw.githubusercontent.com/mockito/mockito.github.io/master/img/logo%402x.png",
     "language": "Java"
   },
   "NativeScript": {


### PR DESCRIPTION
Adds the GORM ORM for Golang

https://gorm.io/

Also removes an unnecessary trailing space in the mockito definition. 