### PR TITLE
Add Material UI & Styled Components, fix Redux Saga imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ One library can be mapped to one single language only, but have multiple import 
 
 An example entry looks like:
 ```
-	"Express": {
-        "language": "JavaScript",
-		"imports": ["express"],
-		"technologies": ["MVC", "Web Development"],
-		"description": "Express is a minimal Node.js framework for web and mobile applications.",
-		"image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png",
-	}
+"Express": {
+  "language": "JavaScript",
+  "imports": ["express"],
+  "technologies": ["MVC", "Web Development"],
+  "description": "Express is a minimal Node.js framework for web and mobile applications.",
+  "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png",
+}
 ```
 
 ### Deep dive into structure

--- a/libraries.json
+++ b/libraries.json
@@ -553,8 +553,8 @@
     "language": "JavaScript"
   },
   "Redux Saga": {
-    "imports": ["redux"],
-    "technologies": ["Web Development"],
+    "imports": ["redux-saga"],
+    "technologies": ["Web Development", "Frontend"],
     "description": "An alternative side effect model for Redux apps.",
     "language": "JavaScript"
   },

--- a/libraries.json
+++ b/libraries.json
@@ -344,6 +344,13 @@
     "image": "https://www.badlogicgames.com/wordpress/wp-content/uploads/2011/05/libGDX-RedGlossyNoReflection.png",
     "language": "Java"
   },
+  "Material UI": {
+    "imports": ["@material-ui"],
+    "technologies": ["Frontend"],
+    "description": "React components for faster and easier web development.",
+    "image": "https://material-ui.com/static/logo_raw.svg",
+    "language": "Javascript"
+  },
   "Materialize CSS": {
     "imports": ["materialize.min.css", "materialize.css"],
     "technologies": ["CSS frameworks"],
@@ -635,6 +642,12 @@
     "description": "MVC framework for creating elegant, modern Java web applications.",
     "image": "https://struts.apache.org/img/struts-logo.svg",
     "language": "Java"
+  },
+  "Styled Components": {
+    "imports": ["styled-components"],
+    "technologies": ["Frontend"],
+    "description": "Styled components is a way to write modular CSS in modern JavaScript.",
+    "language": "Javascript"
   },
   "Svelte": {
     "imports": ["svelte"],


### PR DESCRIPTION
With these changes I want to:

- update the Redux Saga imports, because currently, from my understanding, codersrank [tracks all redux imports](https://github.com/codersrank-org/libraries/blob/master/libraries.json#L556)  as if they were related to Redux Saga, however, they may not necessarily be.
- add Material UI library.
- add Styled Components library.
- Improve indentation in readme's example.

Let me know if there is anything to modify in my changes. ✌️