### PR TITLE
Add Database libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,28 +2,35 @@
 This repository contains a list of supported libraries, imports and technologies they belong to.
 
 ## Structure
-The entire list as stored as a JSON object, where the library name is the key, and the value of such
-property is a number of attributes such as import pattern, language, description, etc.
+The entire list stored as a JSON object, top level key is the language, inside that there are library objects where 
+names are the keys, and the value of such property is a number of attributes such as import pattern, description, etc.
 
-One library can be mapped to one single language only, but have multiple import patterns or technologies.
+One library can appear in multiple languages and can have multiple import patterns or technologies.
 
 An example entry looks like:
 ```
-"Express": {
-  "language": "JavaScript",
-  "imports": ["express"],
-  "technologies": ["MVC", "Web Development"],
-  "description": "Express is a minimal Node.js framework for web and mobile applications.",
-  "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png",
+"JavaScript": {
+  ..
+  "Express": {
+    "imports": ["express"],
+    "technologies": ["MVC", "Web Development"],
+    "description": "Express is a minimal Node.js framework for web and mobile applications.",
+    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png"
+  },
+  ..
 }
 ```
 
 ### Deep dive into structure
-As mentioned before, the key of the object is the ***library name***.
+As mentioned before, top level objects are the languages. Inside a language, 
+there are libraries which are belong to the that language and the key of that object is the ***library name***.
 
 ***Language*** defines what language this library belongs to. One library can be mapped to one language only, so in case of 
 ambiguous libraries like Bootstrap, the choice has to be made which language it is mainly. Bootstrap is mainly CSS, even
 though it involves some JavaScript. 
+
+One exception to this rule is, when the same library has different wrappers for different languages. For example `mongoose` can be used in JavaScript, TypeScript and C. So there are 3 
+`mongoose` objects (for each language), with their own import styles.
 
 ***Imports*** is an array of strings, that all map to this library. During the analysis of the repository, CodersRank extracts
 imports that were used in the commits authored by the user. This may have a form of
@@ -52,7 +59,7 @@ mapped to one of more technologies, as in the original example.
 All contributions are welcome, and CodersRank relies on such support. The rules are few, but essential:
 
 - All fields apart of `description` and `image` are required.
-- Maintain alphabetical order for `libraries`. Think SQL `ORDER BY library`.
+- Maintain alphabetical order for `libraries` and `languages`. Think SQL `ORDER BY library`.
 - If providing description, make sure to include the dot `.` at the end of the line. Also make sure the spelling is correct and the description is accurate.
 
 ## TODO

--- a/libraries.json
+++ b/libraries.json
@@ -830,6 +830,16 @@
       ],
       "description":"MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP)"
     },
+    "mongoose":{
+      "imports":[
+        "mongoose"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB object modeling designed to work in an asynchronous environment."
+    },
     "NativeScript":{
       "imports":[
         "nativescript"

--- a/libraries.json
+++ b/libraries.json
@@ -209,6 +209,16 @@
       ],
       "description":"GORM is a fully-featured ORM library for Golang supporting MySQL, SQLite3, PostgreSQL and Microsoft SQL Server."
     },
+    "mgo": {
+      "imports":[
+        "github.com/globalsign/mgo"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB driver for Go"
+    },
     "Ponzu":{
       "imports":[
         "github.com/ponzu-cms/ponzu"

--- a/libraries.json
+++ b/libraries.json
@@ -872,6 +872,16 @@
       ],
       "description":"MongoDB object modeling designed to work in an asynchronous environment."
     },
+    "mysql":{
+      "imports":[
+        "mysql"
+      ],
+      "technologies":[
+        "Databases",
+        "MySQL"
+      ],
+      "description":"A pure node.js JavaScript Client implementing the MySQL protocol."
+    },
     "NativeScript":{
       "imports":[
         "nativescript"

--- a/libraries.json
+++ b/libraries.json
@@ -487,6 +487,16 @@
       "description":"Bootstrap a Spring application with little or no configuration.",
       "image":"https://spring.io/images/spring-logo-9146a4d3298760c2e7e49595184e1975.svg"
     },
+    "spring-data-mongodb": {
+      "imports":[
+        "com.mongodb.client"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"Provide support to increase developer productivity in Java when using MongoDB."
+    },
     "Struts":{
       "imports":[
         "org.apache.struts2",

--- a/libraries.json
+++ b/libraries.json
@@ -276,6 +276,17 @@
       "description":"Unified analytics engine for large-scale data processing.",
       "image":"https://spark.apache.org/images/spark-logo-trademark.png"
     },
+    "Cayenne":{
+      "imports":[
+        "org.apache.cayenne"
+      ],
+      "technologies":[
+        "Databases",
+        "ORM",
+        "MySQL"
+      ],
+      "description":"Apache Cayenne™ is an open source Java object-to-relational mapping framework"
+    },
     "Gson":{
       "imports":[
         "com.google.gson"

--- a/libraries.json
+++ b/libraries.json
@@ -599,6 +599,16 @@
       ],
       "description":"Carlo provides Node applications with Google Chrome rendering capabilities, communicates with the locally-installed browser instance using the Puppeteer project, and implements a remote call infrastructure for communication between Node and the browser."
     },
+    "camo":{
+      "imports":[
+        "camo"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"A class-based ES6 ODM for Mongo-like databases."
+    },
     "Chai":{
       "imports":[
         "chai"

--- a/libraries.json
+++ b/libraries.json
@@ -1069,6 +1069,16 @@
       ],
       "description":"Javascript library for PostgreSQL and node.js"
     },
+    "Postgres.js":{
+      "imports":[
+        "postgres"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"The Fastest full featured PostgreSQL client for Node.js"
+    },
     "Proton Native":{
       "imports":[
         "proton-native"
@@ -1795,6 +1805,16 @@
         "PostgreSQL"
       ],
       "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
+    },
+    "Postgres.js":{
+      "imports":[
+        "postgres"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"The Fastest full featured PostgreSQL client for Node.js"
     },
     "Slonik":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -474,6 +474,16 @@
       ],
       "description":"A powerful image downloading and caching library for Android."
     },
+    "PgJDBC":{
+      "imports":[
+        "org.postgresql"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL JDBC Driver (PgJDBC for short) allows Java programs to connect to a PostgreSQL database using standard, database independent Java code."
+    },
     "Retrofit":{
       "imports":[
         "com.squareup.retrofit"

--- a/libraries.json
+++ b/libraries.json
@@ -249,6 +249,16 @@
         "CMS"
       ],
       "description":"Headless CMS with automatic JSON API. Featuring auto-HTTPS from Let's Encrypt, HTTP/2 Server Push, and flexible server framework written in Go."
+    },
+    "pq":{
+      "imports":[
+        "github.com/lib/pq"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"A pure Go postgres driver for Go's database/sql package"
     }
   },
   "Groovy":{

--- a/libraries.json
+++ b/libraries.json
@@ -212,6 +212,16 @@
       ],
       "description":"Go Micro provides the core requirements for distributed systems development including RPC and Event driven communication."
     },
+    "Go-MySQL-Driver":{
+      "imports":[
+        "github.com/go-sql-driver/mysql"
+      ],
+      "technologies":[
+        "Databases",
+        "MySQL"
+      ],
+      "description":"Go MySQL Driver is a MySQL driver for Go's (golang) database/sql package"
+    },
     "GORM":{
       "imports":[
         "github.com/jinzhu/gorm"

--- a/libraries.json
+++ b/libraries.json
@@ -1519,6 +1519,16 @@
     }
   },
   "Python":{
+    "asyncpg":{
+      "imports":[
+        "asyncpg"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"asyncpg is a database interface library designed specifically for PostgreSQL and Python/asyncio."
+    },
     "Behave":{
       "imports":[
         "behave"

--- a/libraries.json
+++ b/libraries.json
@@ -1457,6 +1457,16 @@
       "description":"Matplotlib is a comprehensive library for creating static, animated, and interactive visualizations in Python.",
       "image":"https://matplotlib.org/_static/logo2_compressed.svg"
     },
+    "MongoEngine":{
+      "imports":[
+        "mongoengine"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"A Python Object-Document-Mapper for working with MongoDB"
+    },
     "NumPy":{
       "imports":[
         "numpy"

--- a/libraries.json
+++ b/libraries.json
@@ -1049,6 +1049,16 @@
       ],
       "description":"Blazing fast, zero configuration web application bundler."
     },
+    "pg-promise":{
+      "imports":[
+        "pg-promise"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL interface for Node.js"
+    },
     "Proton Native":{
       "imports":[
         "proton-native"
@@ -1695,6 +1705,16 @@
       ],
       "description":"Angular is an open source web application platform.",
       "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png"
+    },
+    "pg-promise":{
+      "imports":[
+        "pg-promise"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL interface for Node.js"
     },
     "mongoose":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -1283,6 +1283,16 @@
       "description":"Lightweight yet powerful web application framework.",
       "image":"http://perldancer.org/images/dcr-header-logo.png"
     },
+    "DBD::Pg":{
+      "imports":[
+        "DBD::Pg"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL database driver for the DBI module"
+    },
     "DBI":{
       "imports":[
         "DBI",

--- a/libraries.json
+++ b/libraries.json
@@ -1542,6 +1542,16 @@
       "description":"Angular is an open source web application platform.",
       "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png"
     },
+    "mongoose":{
+      "imports":[
+        "mongoose"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB object modeling designed to work in an asynchronous environment."
+    },
     "NestJS":{
       "imports":[
         "@nestjs/"

--- a/libraries.json
+++ b/libraries.json
@@ -402,6 +402,16 @@
       ],
       "description":"MongoDB object-document mapper in Java"
     },
+    "MySQL": {
+      "imports":[
+        "com.mysql"
+      ],
+      "technologies":[
+        "Databases",
+        "MySQL"
+      ],
+      "description":"MySQL driver for Java"
+    },
     "OkHttp":{
       "imports":[
         "com.squareup.okhttp"

--- a/libraries.json
+++ b/libraries.json
@@ -1289,6 +1289,16 @@
       "description":"A PHP framework for web artisans.",
       "image":"https://user-images.githubusercontent.com/10347617/73778440-479a8280-479c-11ea-8446-1ab4b0f5c7fd.png"
     },
+    "Laravel MongoDB":{
+      "imports":[
+        "Jenssegers\\"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"A MongoDB based Eloquent model and Query builder for Laravel"
+    },
     "Phalcon":{
       "imports":[
         "Phalcon\\"

--- a/libraries.json
+++ b/libraries.json
@@ -1,4 +1,16 @@
 {
+  "C": {
+    "mongoose":{
+      "imports":[
+        "mongoose.h"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB object modeling designed to work in an asynchronous environment."
+    }
+  },
   "CSS":{
     "Bootstrap":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -360,6 +360,26 @@
       "description":"Mocking framework for unit tests in Java",
       "image":"https://raw.githubusercontent.com/mockito/mockito.github.io/master/img/logo%402x.png"
     },
+    "mongo-java-driver": {
+      "imports":[
+        "org.mongodb"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"The Java driver for MongoDB"
+    },
+    "morphia": {
+      "imports":[
+        "org.mongodb.morphia"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB object-document mapper in Java"
+    },
     "OkHttp":{
       "imports":[
         "com.squareup.okhttp"

--- a/libraries.json
+++ b/libraries.json
@@ -1503,6 +1503,16 @@
       "description":"Pyglet is a cross-platform windowing and multimedia library for Python, intended for developing games and other visually rich applications.",
       "image":"https://pyglet.readthedocs.io/en/stable/_static/logo.png"
     },
+    "PyMongo":{
+      "imports":[
+        "pymongo"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"PyMongo - the Python driver for MongoDB"
+    },
     "PyQt":{
       "imports":[
         "PyQt5",

--- a/libraries.json
+++ b/libraries.json
@@ -1157,6 +1157,16 @@
       ],
       "description":"Featuring the fastest and most reliable real-time engine."
     },
+    "Slonik":{
+      "imports":[
+        "slonik"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"A PostgreSQL client with strict types, detailed logging and assertions."
+    },
     "Styled Components":{
       "imports":[
         "styled-components"
@@ -1785,6 +1795,16 @@
         "PostgreSQL"
       ],
       "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
+    },
+    "Slonik":{
+      "imports":[
+        "slonik"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"A PostgreSQL client with strict types, detailed logging and assertions."
     },
     "Ts.ED":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -1019,6 +1019,16 @@
       ],
       "description":"The Official MongoDB Node.js Driver"
     },
+    "node-postgres":{
+      "imports":[
+        "pg"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
+    },
     "NuxtJS":{
       "imports":[
         "nuxtjs"
@@ -1725,6 +1735,16 @@
         "MongoDB"
       ],
       "description":"The Official MongoDB Node.js Driver"
+    },
+    "node-postgres":{
+      "imports":[
+        "pg"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
     },
     "Ts.ED":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -259,6 +259,17 @@
         "PostgreSQL"
       ],
       "description":"A pure Go postgres driver for Go's database/sql package"
+    },
+    "pgx":{
+      "imports":[
+        "github.com/jackc/pgx/v4",
+        "github.com/jackc/pgx"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL Driver and Toolkit"
     }
   },
   "Groovy":{

--- a/libraries.json
+++ b/libraries.json
@@ -927,6 +927,16 @@
       "description":"JavaScript runtime built on V8 engine and libuv",
       "image":"https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg"
     },
+    "node-mongodb-native":{
+      "imports":[
+        "mongodb"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"The Official MongoDB Node.js Driver"
+    },
     "NuxtJS":{
       "imports":[
         "nuxtjs"
@@ -1583,6 +1593,16 @@
         "SPA"
       ],
       "description":"RxJS powered state management for Angular applications, inspired by Redux"
+    },
+    "node-mongodb-native":{
+      "imports":[
+        "mongodb"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"The Official MongoDB Node.js Driver"
     },
     "Ts.ED":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -1455,6 +1455,18 @@
       "description":"Open Source Digital Experience Platform: MDM/PIM, CDP, DAM, CMS/UX and eCommerce",
       "image":"https://github.com/pimcore/pimcore/raw/master/doc/Development_Documentation/img/logo-readme.svg"
     },
+    "Pomm":{
+      "imports":[
+        "PommProject\\",
+        "pomm/pomm",
+        "pomm-project/pomm-bundle"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"O"
+    },
     "ReactPHP":{
       "imports":[
         "React\\",

--- a/libraries.json
+++ b/libraries.json
@@ -1,933 +1,1516 @@
 {
-  "AfterJS": {
-    "imports": ["@jaredpalmer/after"],
-    "technologies": ["Server side rendering"],
-    "description": "After.js enables Next.js-like data fetching with any React SSR app that uses React Router 4.",
-    "language": "JavaScript"
-  },
-  "Angular": {
-    "imports": ["@angular/", "angular2"],
-    "technologies": ["Frontend", "Web Development", "SPA"],
-    "description": "Angular is an open source web application platform.",
-    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png",
-    "language": "TypeScript"
-  },
-  "Angular Universal": {
-    "imports": ["@nguniversal/"],
-    "technologies": ["Web Development", "SPA", "Server side rendering"],
-    "description": "A technology that renders Angular applications on the server.",
-    "language": "JavaScript"
-  },
-  "AngularJS": {
-    "imports": ["angular"],
-    "technologies": ["Frontend", "Web Development", "SPA"],
-    "description": "AngularJS is a predecessor of Angular, an open source web application platform.",
-    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png",
-    "language": "JavaScript"
-  },
-  "AnimeJS": {
-    "imports": ["anime.js"],
-    "technologies": ["Frontend", "Animation"],
-    "description": "Anime.js is a lightweight JavaScript animation library with a simple, yet powerful API. It works with CSS properties, SVG, DOM attributes and JavaScript Objects.",
-    "image": "https://animejs.com/documentation/assets/img/anime-mini-logo.svg",
-    "language": "JavaScript"
-  },
-  "Apache Spark": {
-    "imports": ["org.apache.spark"],
-    "technologies": ["Data Processing", "Backend"],
-    "description": "Unified analytics engine for large-scale data processing.",
-    "image": "https://spark.apache.org/images/spark-logo-trademark.png",
-    "language": "Java"
-  },
-  "ASP.NET": {
-    "imports": ["Microsoft.AspNetCore.Mvc"],
-    "technologies": ["Web Development", "SPA", "Server side rendering"],
-    "description": "ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends.",
-    "language": "C#"
-  },
-  "BabylonJS": {
-    "imports": ["babylonjs"],
-    "technologies": ["WebGL"],
-    "description": "Powerful, beautiful, simple, open, web-based 3D at its best",
-    "language": "JavaScript"
-  },
-  "Behave": {
-    "imports": ["behave"],
-    "technologies": ["Testing"],
-    "description": "Behave is behaviour-driven development, Python style.",
-    "image": "https://camo.githubusercontent.com/cf89b9309dfd7ca1fa954bdd7f63ca29b6c4497c/68747470733a2f2f7261772e6769746875622e636f6d2f6265686176652f6265686176652f6d61737465722f646f63732f5f7374617469632f6265686176655f6c6f676f312e706e67",
-    "language": "Python"
-  },
-  "Blazor": {
-    "imports": ["Microsoft.AspNetCore.Components.Web"],
-    "technologies": ["Frontend", "WebAssembly"],
-    "description": "Blazor is a framework for building interactive client-side web UI with .NET",
-    "image": "https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2019/04/BrandBlazor_nohalo_1000x.png",
-    "language": "C#"
-  },
-  "Bootstrap": {
-    "imports": ["bootstrap.css", "boostrap.min.css"],
-    "technologies": ["Frontend", "CSS frameworks"],
-    "description": "Bootstrap is an open source toolkit for developing with HTML, CSS, and JS.",
-    "image": "https://mdbootstrap.com/img/logo/brands/bootstrap.jpg",
-    "language": "CSS"
-  },
-  "Bulma": {
-    "imports": ["bulma.css"],
-    "technologies": ["Frontend", "CSS frameworks"],
-    "description": "Bulma is a free, open source CSS framework based on Flexbox and used by more than 200,000 developers.",
-    "language": "CSS"
-  },
-  "Carlo": {
-    "imports": ["carlo"],
-    "technologies": ["Desktop applications"],
-    "description": "Carlo provides Node applications with Google Chrome rendering capabilities, communicates with the locally-installed browser instance using the Puppeteer project, and implements a remote call infrastructure for communication between Node and the browser.",
-    "language": "JavaScript"
-  },
-  "Chai": {
-    "imports": ["chai"],
-    "technologies": ["Testing"],
-    "description": "Chai is a BDD / TDD assertion library for Node.js and the browser.",
-    "image": "https://www.chaijs.com/img/chai-logo.png",
-    "language": "JavaScript"
-  },
-  "ChartJS": {
-    "imports": ["chart.js"],
-    "technologies": ["Frontend", "Data Visualization"],
-    "description": "A simple yet flexible Javascript charting library for Designers and Developers.",
-    "image": "https://www.chartjs.org/media/logo-title.svg",
-    "language": "JavaScript"
-  },
-  "CHI": {
-    "imports": ["CHI"],
-    "technologies": ["Scalability"],
-    "description": "Unified cache handling interface.",
-    "language": "Perl"
-  },
-  "Cypress": {
-    "imports": ["cypress"],
-    "technologies": ["Testing"],
-    "description": "Cypress is a Javascript End to End testing framework",
-    "language": "JavaScript"
-  },
-  "D3": {
-    "imports": ["d3"],
-    "technologies": ["Frontend", "Data Visualization"],
-    "description": "D3 (or D3.js) is a JavaScript library for visualizing data using web standards. D3 helps you bring data to life using SVG, Canvas and HTML DOM manipulation.",
-    "image": "https://d3js.org/logo.svg",
-    "language": "JavaScript"
-  },
-  "Dancer": {
-    "imports": ["Dancer"],
-    "technologies": ["Web Development", "MVC"],
-    "description": "Lightweight yet powerful web application framework.",
-    "image": "http://perldancer.org/images/dcr-header-logo.png",
-    "language": "Perl"
-  },
-  "DBI": {
-    "imports": ["DBI", "DBD"],
-    "technologies": ["Databases"],
-    "description": "Database independent interface for Perl.",
-    "language": "Perl"
-  },
-  "DBIx::Class": {
-    "imports": ["DBIx::Class"],
-    "technologies": ["ORM"],
-    "description": "Extensible and flexible object <-> relational mapper.",
-    "language": "Perl"
-  },
-  "Django": {
-    "imports": ["django"],
-    "technologies": ["Web Development"],
-    "description": "Django is a high-level Python Web framework that encourages rapid development and clean, pragmatic design.",
-    "language": "Python"
-  },
-  "Django REST framework": {
-    "imports": ["rest_framework"],
-    "technologies": ["Web Development"],
-    "description": "Django REST framework is a powerful and flexible toolkit for building Web APIs.",
-    "language": "Python"
-  },
-  "Echo": {
-    "imports": ["github.com/labstack/echo"],
-    "technologies": ["framework"],
-    "description": "High performance, minimalist Go web framework.",
-    "language": "Go"
-  },
-  "Effector": {
-    "imports": ["effector"],
-    "technologies": ["Web Development", "SPA"],
-    "description": "Effective multi-store state manager for Javascript apps",
-    "language": "JavaScript"
-  },
-  "Electron": {
-    "imports": ["electron"],
-    "technologies": ["Desktop applications"],
-    "description": "Build cross platform desktop apps with JavaScript, HTML, and CSS",
-    "language": "JavaScript"
-  },
-  "Emotion": {
-    "imports": ["@emotion/"],
-    "technologies": ["Frontend", "CSS frameworks"],
-    "description": "Emotion is a library designed for writing css styles with JavaScript.",
-    "language": "CSS"
-  },
-  "Entity Framework": {
-    "imports": ["Microsoft.EntityFrameworkCore"],
-    "technologies": ["ORM"],
-    "description": "Entity Framework Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations.",
-    "language": "C#"
-  },
-  "Enzyme": {
-    "imports": ["enzyme"],
-    "technologies": ["Testing"],
-    "description": "Enzyme is a JavaScript Testing utility for React that makes it easier to test your React Components' output",
-    "language": "JavaScript"
-  },
-  "ExpressJS": {
-    "imports": ["express"],
-    "technologies": ["Web Development", "JavaScript Frameworks", "Backend"],
-    "description": "Express is a minimal Node.js framework for web.",
-    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png",
-    "language": "JavaScript"
-  },
-  "Flask": {
-    "imports": ["flask"],
-    "technologies": ["Web Development"],
-    "description": "Flask is a lightweight WSGI web application framework. It is designed to make getting started quick and easy, with the ability to scale up to complex applications.",
-    "language": "Python"
-  },
-  "Flow": {
-    "imports": ["flowjs"],
-    "_comment": "This is a special keyword, see repo info extractor JavaScript parser",
-    "technologies": ["Web Development"],
-    "description": "Flow is a static type checker for JavaScript, it works in a similar way that a linter does.",
-    "language": "JavaScript"
-  },
-  "Flutter": {
-    "imports": ["package:flutter"],
-    "technologies": ["Mobile Development"],
-    "description": "Flutter is Google's UI toolkit for crafting beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.",
-    "image": "https://upload.wikimedia.org/wikipedia/commons/1/17/Google-flutter-logo.png",
-    "language": "Dart"
-  },
-  "Framework7": {
-    "imports": ["framework7"],
-    "technologies": [
-      "Mobile applications",
-      "Desktop applications",
-      "Progressive Web Apps",
-      "CSS frameworks"
-    ],
-    "description": "A free and open source framework to develop mobile, desktop or web apps with native look and feel",
-    "language": "JavaScript"
-  },
-  "Gin": {
-    "imports": ["github.com/gin-gonic/gin"],
-    "technologies": ["Web Development", "Backend"],
-    "description": "Gin is a HTTP web framework written in Go (Golang).",
-    "image": "https://raw.githubusercontent.com/gin-gonic/logo/master/color.png",
-    "language": "Go"
-  },
-  "Glamorous": {
-    "imports": ["glamorous"],
-    "technologies": ["Frontend", "CSS frameworks"],
-    "description": "Maintainable CSS with React.",
-    "language": "CSS"
-  },
-  "Go Micro": {
-    "imports": ["github.com/micro/go-micro"],
-    "technologies": ["microservice"],
-    "description": "Go Micro provides the core requirements for distributed systems development including RPC and Event driven communication.",
-    "language": "Go"
-  },
-  "GORM": {
-    "imports": ["github.com/jinzhu/gorm"],
-    "technologies": ["ORM"],
-    "description": "GORM is a fully-featured ORM library for Golang supporting MySQL, SQLite3, PostgreSQL and Microsoft SQL Server.",
-    "language": "Go"
-  },
-  "Grails": {
-    "imports": ["grails"],
-    "technologies": ["Web Development", "Java Frameworks"],
-    "description": "A powerful Groovy-based web application framework for the JVM built on top of Spring Boot",
-    "image": "https://raw.githubusercontent.com/apache/groovy-website/asf-site/site/src/site/assets/img/groovy-logo-colored.svg",
-    "language": "Groovy"
-  },
-  "Graphene": {
-    "imports": ["graphene"],
-    "technologies": ["Web Development", "Python Library"],
-    "description": "GraphQL in Python Made Easy.",
-    "image": "https://avatars2.githubusercontent.com/u/15002022?s=200&v=4",
-    "language": "Python"
-  },
-  "GraphQL": {
-    "imports": ["graphql-express", "graphql"],
-    "technologies": ["Web Development", "JavaScript Frameworks"],
-    "description": "A query language for your API",
-    "image": "https://uploads.getpop.org/wp-content/uploads/2019/07/graphql-480x480.png",
-    "language": "JavaScript"
-  },
-  "Gson": {
-    "imports": ["com.google.gson"],
-    "technologies": ["JSon"],
-    "description": "Gson is a Java library that can be used to convert Java Objects into their JSON representation.",
-    "image": "https://s.appbrain.com/static/202005201421235/blob/sdk-logos/google_gson.png",
-    "language": "Java"
-  },
-  "Gulp": {
-    "imports": ["gulp"],
-    "technologies": ["Build tools"],
-    "description": "Gulp is an open-source JavaScript toolkit created by Eric Schoffstall used as a streaming build system in front-end web development.",
-    "language": "JavaScript"
-  },
-  "GWT": {
-    "imports": ["com.google.gwt"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend"],
-    "description": "Development toolkit for building and optimizing complex browser-based applications..",
-    "image": "http://www.gwtproject.org/assets/build/img/navLogoBig.png",
-    "language": "Java"
-  },
-  "Hapi": {
-    "imports": ["@hapi/", "hapi"],
-    "technologies": ["Web Development", "JavaScript Frameworks", "Backend"],
-    "description": "Hapi is a simple, secure web framework for Node.js.",
-    "image": "https://raw.githubusercontent.com/hapijs/assets/master/images/hapi.png",
-    "language": "JavaScript"
-  },
-  "Hibernate": {
-    "imports": ["org.hibernate"],
-    "technologies": ["ORM"],
-    "description": "Domain model persistence and Data library for Java.",
-    "language": "Java"
-  },
-  "Impress": {
-    "imports": ["impress"],
-    "technologies": ["Backend", "Private Cloud", "Application Server"],
-    "description": "Application Server for Node.js Private Cloud",
-    "image": "https://github.com/metarhia/Metarhia/blob/master/Logos/impress-with-text.svg",
-    "language": "JavaScript"
-  },
-  "IO::Async": {
-    "imports": ["IO::Async"],
-    "technologies": ["Async Programming"],
-    "description": "Asynchronous event-driven programming.",
-    "language": "Perl"
-  },
-  "Ionic": {
-    "imports": ["@ionic/"],
-    "technologies": ["Mobile applications"],
-    "description": "Ionic is the app development platform for web developers",
-    "language": "JavaScript"
-  },
-  "Jakarta Server Faces (JSF)": {
-    "imports": ["javax.faces", "com.sun.faces"],
-    "technologies": ["Web Development", "Java Frameworks", "Frontend", "Backend"],
-    "description": "MVC framework for building user interfaces for web applications.",
-    "image": "https://jakarta.ee/images/jakarta/jakarta-ee-logo.svg",
-    "language": "Java"
-  },
-  "Jersey": {
-    "imports": ["org.glassfish.jersey"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend", "REST"],
-    "description": "Web services framework to create RESTful services.",
-    "image": "https://eclipse-ee4j.github.io/jersey.github.io/images/jersey_logo.png",
-    "language": "Java"
-  },
-  "Jest": {
-    "imports": ["jest"],
-    "technologies": ["Testing"],
-    "description": "Jest is a delightful JavaScript Testing Framework with a focus on simplicity",
-    "language": "JavaScript"
-  },
-  "JUnit": {
-    "imports": ["org.junit", "junit"],
-    "technologies": ["Testing"],
-    "description": "JUnit is a unit-testing framework for Java.",
-    "image": "https://junit.org/junit4/images/junit-logo.png",
-    "language": "Java"
-  },
-  "Keras": {
-    "imports": ["keras", "tensorflow.keras"],
-    "technologies": [
-      "Machine Learning",
-      "Deep Learning",
-      "Backend"
-    ],
-    "description": "Keras is a deep learning API written in Python, running on top of the machine learning platform TensorFlow. It was developed with a focus on enabling fast experimentation. Being able to go from idea to result as fast as possible is key to doing good research.",
-    "image": "https://keras.io/img/logo.png",
-    "language": "Python"
-  },
-  "Kivy": {
-    "imports": ["kivy"],
-    "technologies": [
-      "Desktop applications",
-      "Mobile applications"
-    ],
-    "description": "Kivy - Open source Python library for rapid development of applications that make use of innovative user interfaces, such as multi-touch apps.",
-    "image": "https://kivy.org/logos/kivy-logo-black-256.png",
-    "language": "Python"
-  },
-  "KiwiJS": {
-    "imports": ["kiwi-js"],
-    "technologies": ["Web Development", "Mobile Development", "Game Development"],
-    "description": "Kiwi.js is a mobile first HTML5 and Javascript game engine supporting both Canvas and WebGL rendering.",
-    "image": "http://www.kiwijs.org/wp-content/themes/kiwijs/assets/logo.png",
-    "language": "JavaScript"
-  },
-  "Koa": {
-    "imports": ["koa"],
-    "technologies": ["Web Development"],
-    "description": "Next generation web framework for Node.js",
-    "image": "https://raw.githubusercontent.com/koajs/koa/f3ede44ffa6b59dcdc4d94d1faaa223aa6c60a51/docs/logo.png",
-    "language": "JavaScript"
-  },
-  "Laravel": {
-    "imports": ["Illuminate\\", "laravel/laravel", "laravel/framework"],
-    "technologies": ["Web Development", "PHP Frameworks", "MVC"],
-    "description": "A PHP framework for web artisans.",
-    "image": "https://user-images.githubusercontent.com/10347617/73778440-479a8280-479c-11ea-8446-1ab4b0f5c7fd.png",
-    "language": "PHP"
-  },
-  "LibGDX": {
-    "imports": ["com.badlogic.gdx"],
-    "technologies": ["Java Frameworks", "Mobile Development", "Game Development", "Desktop Development", "Desktop Applications", "Mobile Applications"],
-    "description": "libGDX is a free and open-source game-development application framework written in the Java programming language with some C and C++ components for performance dependent code. It allows for the development of desktop and mobile games by using the same code base. It is cross-platform, supporting Windows, Linux, Mac OS X, Android, iOS, BlackBerry and web browsers with WebGL support.",
-    "image": "https://www.badlogicgames.com/wordpress/wp-content/uploads/2011/05/libGDX-RedGlossyNoReflection.png",
-    "language": "Java"
-  },
-  "Log::Log4perl": {
-    "imports": ["Log::Log4perl"],
-    "technologies": ["Logging"],
-    "description": "Log4j implementation for Perl.",
-    "language": "Perl"
-  },
-  "Material UI": {
-    "imports": ["@material-ui"],
-    "technologies": ["Frontend"],
-    "description": "React components for faster and easier web development.",
-    "image": "https://material-ui.com/static/logo_raw.svg",
-    "language": "Javascript"
-  },
-  "Materialize CSS": {
-    "imports": ["materialize.min.css", "materialize.css"],
-    "technologies": ["CSS frameworks"],
-    "description": "A modern responsive front-end framework based on Material Design",
-    "language": "CSS"
-  },
-  "Matplotlib": {
-    "imports": ["matplotlib"],
-    "technologies": ["Data Visualization"],
-    "description": "Matplotlib is a comprehensive library for creating static, animated, and interactive visualizations in Python.",
-    "image": "https://matplotlib.org/_static/logo2_compressed.svg",
-    "language": "Python"
-  },
-  "MCE": {
-    "imports": ["MCE"],
-    "technologies": ["Parallel Computing"],
-    "description": "Many-Core Engine for Perl providing parallel processing capabilities.",
-    "language": "Perl"
-  },
-  "MeteorJS": {
-    "imports": ["meteor"],
-    "technologies": ["Web Development", "SPA", "Full Stack"],
-    "description": "Meteor.js is a full stack framework. It means that you can control everything from the database to the UI with the same language and the same framework, and it is one of Meteor’s primary advantages.",
-    "image": "https://user-images.githubusercontent.com/841294/26841702-0902bbee-4af3-11e7-9805-0618da66a246.png",
-    "language": "JavaScript"
-  },
-  "Micronaut": {
-    "language": "Java",
-    "imports": ["io.micronaut"],
-    "technologies": ["Web Development", "Microservices", "Java Frameworks"],
-    "description": "Micronaut is a modern, JVM-based, full-stack framework for building modular, easily testable microservice and serverless applications.",
-    "image": "https://raw.githubusercontent.com/micronaut-projects/static-website/master/main/src/main/resources/assets/images/micronaut_mini.svg"
-  },
-  "MobX": {
-    "imports": ["mobx"],
-    "technologies": ["Web Development", "SPA"],
-    "description": "MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP)",
-    "language": "JavaScript"
-  },
-  "Mockito": {
-    "imports": ["org.mockito"],
-    "technologies": ["Testing"],
-    "description": "Mocking framework for unit tests in Java",
-    "image": "https://raw.githubusercontent.com/mockito/mockito.github.io/master/img/logo%402x.png",
-    "language": "Java"
-  },
-  "Mojolicious": {
-    "imports": ["Mojolicious"],
-    "technologies": ["Web Development", "MVC"],
-    "description": "Real-time web framework.",
-    "image": "https://mojolicious.org/favicon.ico",
-    "language": "Perl"
-  },
-  "Moo": {
-    "imports": ["Moo"],
-    "technologies": ["Object Oriented Programming"],
-    "description": "Minimalist Object Orientation.",
-    "language": "Perl"
-  },
-  "Moose": {
-    "imports": ["Moose"],
-    "technologies": ["Object Oriented Programming"],
-    "description": "A postmodern object system for Perl 5.",
-    "language": "Perl"
-  },
-  "NativeScript": {
-    "imports": ["nativescript"],
-    "technologies": ["Mobile applications"],
-    "description": "Open source framework for building truly native mobile apps with Angular, Vue.js, TypeScript, or JavaScript.",
-    "language": "JavaScript"
-  },
-  "NativeScriptVue": {
-    "imports": ["nativescript-vue"],
-    "technologies": ["Mobile applications", "JavaScript Frameworks"],
-    "description": "Open source framework for building truly native mobile apps with Vue.js.",
-    "image": "https://art.nativescript-vue.org/NativeScript-Vue-White-Green.svg",
-    "language": "JavaScript"
-  },
-  "Neo4j" : {
-    "imports": ["neo4j", "neo4j-driver"],
-    "technologies": ["Java", "JavaScript", "Databases"],
-    "description": "Neo4j is a graph database management system developed by Neo4j, Inc.",
-    "image": "https://go.neo4j.com/rs/710-RRC-335/images/neo4j_logo_globe.png",
-    "language": "JavaScript"
-  },
-  "NestJS": {
-    "imports": ["@nestjs/"],
-    "technologies": ["Web Development"],
-    "description": "A progressive Node.js framework for building efficient, reliable and scalable server-side applications.",
-    "image": "https://nestjs.com/img/logo-small.svg",
-    "language": "TypeScript"
-  },
-  "NextJS": {
-    "imports": ["nextjs"],
-    "technologies": ["Web Development", "SPA", "Server side rendering"],
-    "description": "Production grade React applications that scale. The world's leading companies use Next.js to build server-rendered applications, static websites, and more.",
-    "language": "JavaScript"
-  },
-  "NgRx": {
-    "imports": ["@ngrx"],
-    "technologies": ["Web Development", "SPA"],
-    "description": "RxJS powered state management for Angular applications, inspired by Redux",
-    "language": "TypeScript"
-  },
-  "NodeJS": {
-    "imports": ["child_process", "cluster", "crypto", "dns", "events", "fs", "http", "http2", "https", "net", "os", "path", "stream", "tls", "udp",  "url", "util", "v8",  "vm", "worker_threads", "zlib"],
-    "technologies": ["Frontend", "Backend"],
-    "description": "JavaScript runtime built on V8 engine and libuv",
-    "image": "https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg",
-    "language": "JavaScript"
-  },
-  "NumPy": {
-    "imports": ["numpy"],
-    "technologies": ["Scientific Computing", "Data Processing", "Data Science"],
-    "description": "The fundamental package for scientific computing with Python.",
-    "image": "https://numpy.org/images/logos/numpy.svg",
-    "language": "Python"
-  },
-  "NUnit": {
-    "imports": ["NUnit.Framework"],
-    "technologies": ["Testing"],
-    "description": "NUnit is a unit-testing framework for all .Net languages.",
-    "image": "https://nunit.org/img/nunit_logo_128.png",
-    "language": "C#"
-  },
-  "NuxtJS": {
-    "imports": ["nuxtjs"],
-    "technologies": ["Web Development", "SPA", "Server side rendering"],
-    "description": "Nuxt.js is a free and open source web application framework based on Vue.js, Node.js, Webpack and Babel.js.",
-    "language": "JavaScript"
-  },
-  "OkHttp": {
-    "imports": ["com.squareup.okhttp"],
-    "technologies": ["Mobile Development", "Java Frameworks"],
-    "description": "OkHttp is an HTTP client that’s efficient by default: HTTP/2 support, reduces request latency... .",
-    "language": "Java"
-  },
-  "Okio": {
-    "imports": ["com.squareup.okio"],
-    "technologies": ["Mobile Development", "Java Frameworks", "Kotlin Frameworks"],
-    "description": "A modern I/O library for Android, Kotlin, and Java.",
-    "language": "Java"
-  },
-  "OpenEdge ABL": {
-    "imports": ["OpenEdge"],
-    "technologies": ["Desktop Applications", "Web Development", "Databases"],
-    "description": "Business application development language created and maintained by Progress Software Corporation",
-    "language": "OpenEdge ABL"
-  },
-  "Pandas": {
-    "imports": ["pandas"],
-    "technologies": ["Scientific Computing", "Data Processing", "Data Science", "Data Analysis"],
-    "description": "Pandas is a fast, powerful, flexible and easy to use open source data analysis and manipulation tool, built on top of the Python programming language.",
-    "image": "https://pandas.pydata.org/static/img/pandas_white.svg",
-    "language": "Python"
-  },
-  "Parallel::ForkManager": {
-    "imports": ["Parallel::ForkManager"],
-    "technologies": ["Parallel Computing"],
-    "description": "A simple parallel processing fork manager.",
-    "language": "Perl"
-  },
-  "Parcel": {
-    "imports": ["parcel"],
-    "technologies": ["Build tools"],
-    "description": "Blazing fast, zero configuration web application bundler.",
-    "language": "JavaScript"
-  },
-  "PatternFly": {
-    "imports": ["@patternfly/patternfly"],
-    "technologies": ["Frontend", "CSS frameworks"],
-    "description": "PatternFly is an open source design system created to enable consistency and usability across a wide range of applications and use cases.",
-    "image": "https://i.github-camo.com/8b1315539cf8078c2d44644f312d8e0f09225361/68747470733a2f2f7777772e7061747465726e666c792e6f72672f6173736574732f696d672f7061747465726e666c792d6f72622e737667",
-    "language": "CSS"
-  },
-  "Phalcon": {
-    "imports": ["Phalcon\\"],
-    "technologies": ["Web Development", "PHP Frameworks"],
-    "description": "High performance, full-stack PHP framework delivered as a C extension.",
-    "image": "https://raw.githubusercontent.com/phalcon/assets/master/phalcon/images/svg/phalcon-logo-300x300.svg",
-    "language": "PHP"
-  },
-  "Picasso": {
-    "imports": ["com.squareup.picasso"],
-    "technologies": ["Mobile Development"],
-    "description": "A powerful image downloading and caching library for Android.",
-    "language": "Java"
-  },
-  "Pimcore": {
-    "imports": ["Pimcore\\", "pimcore/pimcore"],
-    "technologies": ["Web Development", "PHP Frameworks", "CMS"],
-    "description": "Open Source Digital Experience Platform: MDM/PIM, CDP, DAM, CMS/UX and eCommerce",
-    "image": "https://github.com/pimcore/pimcore/raw/master/doc/Development_Documentation/img/logo-readme.svg",
-    "language": "PHP"
-  },
-  "POE": {
-    "imports": ["POE"],
-    "technologies": ["Async Programming"],
-    "description": "Portable multitasking and networking framework for any event loop.",
-    "language": "Perl"
-  },
-  "Ponzu": {
-    "imports": ["github.com/ponzu-cms/ponzu"],
-    "technologies": ["CMS"],
-    "description": "Headless CMS with automatic JSON API. Featuring auto-HTTPS from Let's Encrypt, HTTP/2 Server Push, and flexible server framework written in Go.",
-    "language": "Go"
-  },
-  "Proton Native": {
-    "imports": ["proton-native"],
-    "technologies": ["Desktop applications"],
-    "description": "Create native desktop applications through a React syntax, on all platforms",
-    "language": "JavaScript"
-  },
-  "Pygame": {
-    "imports": ["pygame"],
-    "technologies": ["Desktop applications", "Game development"],
-    "description": "Pygame is a cross-platform set of Python modules designed for writing video games. It includes computer graphics and sound libraries designed to be used with the Python programming language.",
-    "image": "http://www.pygame.org/docs/pygame_small.gif",
-    "language": "Python"
-  },
-  "Pyglet": {
-    "imports": ["pyglet"],
-    "technologies": ["Desktop applications"],
-    "description": "Pyglet is a cross-platform windowing and multimedia library for Python, intended for developing games and other visually rich applications.",
-    "image": "https://pyglet.readthedocs.io/en/stable/_static/logo.png",
-    "language": "Python"
-  },
-  "PyQt": {
-    "imports": ["PyQt5", "PyQt4"],
-    "technologies": ["Desktop applications"],
-    "description": "PyQt is one of the most popular Python bindings for the Qt cross-platform C++ framework",
-    "language": "Python"
-  },
-  "Pyramid": {
-    "imports": ["pyramid"],
-    "technologies": ["Web Development"],
-    "description": "Pyramid makes it easy to write web applications. You can start small with this \"hello world\" minimal request/response web app. This may take you far, especially while learning. As your application grows, Pyramid offers many features that make writing complex software take less effort.",
-    "image": "https://trypyramid.com/img/pyramid-60x60.png",
-    "language": "Python"
-  },
-  "Pytest": {
-    "imports": ["pytest"],
-    "technologies": ["Testing"],
-    "description": "Pytest is a framework that makes building simple and scalable tests easy.",
-    "image": "https://docs.pytest.org/en/stable/_static/pytest1.png",
-    "language": "Python"
-  },
-  "Radium": {
-    "imports": ["radium"],
-    "technologies": ["Frontend", "Web Development", "CSS Frameworks"],
-    "description": "A set of tools to manage inline styles on React elements, giving you powerful styling capabilities without CSS",
-    "language": "CSS"
-  },
-  "Rails": {
-    "imports": ["rails"],
-    "technologies": ["Web Development", "MVC"],
-    "description": "Rails is a web application development framework written in the Ruby programming language. It is designed to make programming web applications easier by making assumptions about what every developer needs to get started.",
-    "image": "https://upload.wikimedia.org/wikipedia/commons/6/62/Ruby_On_Rails_Logo.svg",
-    "language": "Ruby"
-  },
-  "React Native": {
-    "imports": ["react-native"],
-    "technologies": ["Mobile applications"],
-    "description": "React Native combines the best parts of native development with React, a best-in-class JavaScript library for building user interfaces.",
-    "language": "JavaScript"
-  },
-  "ReactJS": {
-    "imports": ["react"],
-    "technologies": [
-      "Frontend",
-      "Web Development",
-      "SPA",
-      "JavaScript Frameworks"
-    ],
-    "description": "A JavaScript library for building user interfaces",
-    "image": "https://cdn4.iconfinder.com/data/icons/logos-3/600/React.js_logo-512.png",
-    "language": "JavaScript"
-  },
-  "ReactPHP": {
-    "imports": ["React\\", "react/react"],
-    "technologies": ["Web Development"],
-    "description": "ReactPHP is a low-level library for event-driven programming in PHP.",
-    "image": "https://avatars3.githubusercontent.com/u/1696866",
-    "language": "PHP"
-  },
-  "Redux": {
-    "imports": ["redux"],
-    "technologies": ["Web Development"],
-    "description": "A predictable state container for JavaScript apps.",
-    "language": "JavaScript"
-  },
-  "Redux Saga": {
-    "imports": ["redux-saga"],
-    "technologies": ["Web Development", "Frontend"],
-    "description": "An alternative side effect model for Redux apps.",
-    "language": "JavaScript"
-  },
-  "Retrofit": {
-    "imports": ["com.squareup.retrofit"],
-    "technologies": ["Mobile Development", "Java Frameworks"],
-    "description": "A type-safe HTTP client for Android and Java.",
-    "language": "Java"
-  },
-  "Rex": {
-    "imports": ["Rex"],
-    "technologies": ["Automation", "DevOps"],
-    "description": "Rex, the friendly automation framework.",
-    "image": "https://www.rexify.org/public/images/skin/rexify.org/favicon.png",
-    "language": "Perl"
-  },
-  "Rollup": {
-    "imports": ["rollup"],
-    "technologies": ["Build tools"],
-    "description": "Parcel is a web application bundler, differentiated by its developer experience. It offers blazing fast performance utilizing multicore processing, and requires zero configuration.",
-    "language": "JavaScript"
-  },
-  "RxJava": {
-    "imports": ["io.reactivex"],
-    "technologies": ["Web Development", "Mobile Development"],
-    "description": "Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM",
-    "language": "Java"
-  },
-  "RxJS": {
-    "imports": ["rxjs"],
-    "technologies": ["Web Development"],
-    "description": "Reactive Extensions Library for JavaScript",
-    "language": "JavaScript"
-  },
-  "Semantic UI": {
-    "imports": ["semantic.min.css", "semantic.css"],
-    "technologies": ["Web Development", "SPA"],
-    "description": "User Interface is the language of the web.",
-    "language": "CSS"
-  },
-  "Sequelize": {
-    "imports": ["sequelize"],
-    "technologies": ["ORM", "NodeJS"],
-    "description": "Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server.",
-    "image": "https://avatars1.githubusercontent.com/u/3591786",
-    "language": "JavaScript"
-  },
-  "SLF4J": {
-    "imports": ["org.slf4j"],
-    "technologies": ["Logging"],
-    "description": "Simple facade or abstraction for various logging frameworks.",
-    "image" : "http://www.slf4j.org/images/logos/slf4j-logo.jpg",
-    "language": "Java"
-  },
-  "Socket.io": {
-    "imports": ["socket.io"],
-    "technologies": ["Websockets"],
-    "description": "Featuring the fastest and most reliable real-time engine.",
-    "language": "JavaScript"
-  },
-  "Spark Java": {
-    "imports": ["spark"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend"],
-    "description": "A micro framework for creating web applications with minimal effort.",
-    "image": "http://sparkjava.com/img/logo.svg",
-    "language": "Java"
-  },
-  "SpeedScript": {
-    "imports": ["OpenEdge"],
-    "technologies": ["Web Development"],
-    "description": "SpeedScript is a subset of OpenEdge ABL language used in the development of web applications",
-    "language": "OpenEdge ABL"
-  },
-  "Spring": {
-    "imports": ["org.springframework"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend"],
-    "description": "Comprehensive programming and configuration model for modern Java-based enterprise applications.",
-    "image": "https://spring.io/images/spring-logo-9146a4d3298760c2e7e49595184e1975.svg",
-    "language": "Java"
-  },
-  "Spring Boot": {
-    "imports": ["org.springframework.boot"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend"],
-    "description": "Bootstrap a Spring application with little or no configuration.",
-    "image": "https://spring.io/images/spring-logo-9146a4d3298760c2e7e49595184e1975.svg",
-    "language": "Java"
-  },
-  "Struts": {
-    "imports": ["org.apache.struts2", "org.apache.struts"],
-    "technologies": ["Web Development", "Java Frameworks", "Frontend", "Backend"],
-    "description": "MVC framework for creating elegant, modern Java web applications.",
-    "image": "https://struts.apache.org/img/struts-logo.svg",
-    "language": "Java"
-  },
-  "Styled Components": {
-    "imports": ["styled-components"],
-    "technologies": ["Frontend"],
-    "description": "Styled components is a way to write modular CSS in modern JavaScript.",
-    "language": "Javascript"
-  },
-  "Svelte": {
-    "imports": ["svelte"],
-    "technologies": ["Web Development", "SPA"],
-    "description": "Svelte is a radical new approach to building user interfaces. Whereas traditional frameworks like React and Vue do the bulk of their work in the browser, Svelte shifts that work into a compile step that happens when you build your app.",
-    "image": "https://raw.githubusercontent.com/sveltejs/branding/master/svelte-logo.png",
-    "language": "JavaScript"
-  },
-  "Symfony": {
-    "imports": ["Symfony\\", "symfony/symfony"],
-    "technologies": ["Web Development", "PHP Frameworks", "MVC"],
-    "description": "Symfony, High Performance PHP Framework for Web Development.",
-    "image": "https://avatars0.githubusercontent.com/u/143937",
-    "language": "PHP"
-  },
-  "Tensorflow": {
-    "imports": ["tensorflow"],
-    "technologies": [
-      "Machine Learning",
-      "Deep Learning",
-      "Backend"
-    ],
-    "description": "TensorFlow is an end-to-end open source platform for machine learning. It has a comprehensive, flexible ecosystem of tools, libraries and community resources that lets researchers push the state-of-the-art in ML and developers easily build and deploy ML powered applications.",
-    "image": "https://www.gstatic.com/devrel-devsite/prod/vbbb6dd37c071e57dbfce1249762e4d342b93b36af15e7676b1059db22e43eb43/tensorflow/images/lockup.svg?dcb_=0.830285463447934",
-    "language": "Python"
-  },
-  "Test2": {
-    "imports": ["Test2"],
-    "technologies": ["Testing"],
-    "description": "Framework for writing test tools that all work together.",
-    "language": "Perl"
-  },
-  "Test::Simple": {
-    "imports": ["Test::Simple", "Test::More"],
-    "technologies": ["Testing"],
-    "description": "Basic utilities for writing tests.",
-    "language": "Perl"
-  },
-  "ThreeJS": {
-    "imports": ["three"],
-    "technologies": ["WebGL"],
-    "description": "Three.js is a cross-browser JavaScript library and Application Programming Interface used to create and display animated 3D computer graphics in a web browser.",
-    "language": "JavaScript"
-  },
-  "Ts.ED": {
-    "imports": ["@tsed/"],
-    "technologies": ["Web Development", "MVC"],
-    "description": "A Node.js and TypeScript Framework on top of ExpressJS.",
-    "language": "TypeScript"
-  },
-  "Twisted": {
-    "imports": ["twisted"],
-    "technologies": ["Web Development", "Backend"],
-    "description": "Event-based framework for internet applications, supporting Python 3.5+.",
-    "image": "https://www.twistedmatrix.com/trac/chrome/common/trac_banner.png",
-    "language": "Python"
-  },
-  "Unity3D": {
-    "imports": ["UnityEngine"],
-    "technologies": ["Game Development"],
-    "description": "Unity is a real-time 3D development platform for creating games and other 3D graphics.",
-    "language": "C#"
-  },
-  "Vaadin": {
-    "imports": ["com.vaadin"],
-    "technologies": ["Web Development", "Java Frameworks", "Frontend", "Backend"],
-    "description": "Full stack framework for building web apps in Java.",
-    "image": "https://vaadin.com/images/vaadin-logo.svg",
-    "language": "Java"
-  },
-  "Vert.x": {
-    "imports": ["io.vertx"],
-    "technologies": ["Web Development", "Java Frameworks", "Backend"],
-    "description": "Tool-kit for building reactive applications on the JVM.",
-    "image": "https://vertx.io/assets/logo-sm.png",
-    "language": "Java"
-  },
-  "VueJS": {
-    "imports": ["vue"],
-    "technologies": [
-      "Frontend",
-      "Web Development",
-      "SPA",
-      "JavaScript Frameworks"
-    ],
-    "description": "The Progressive JavaScript Framework",
-    "image": "https://raw.githubusercontent.com/vuejs/art/master/logo.png",
-    "language": "JavaScript"
-  },
-  "VueX": {
-    "imports": ["vuex"],
-    "technologies": ["Web Development", "SPA", "JavaScript Frameworks"],
-    "description": "Centralized State Management for Vue.js.",
-    "language": "JavaScript"
-  },
-  "Webpack": {
-    "imports": ["webpack"],
-    "technologies": ["Build tools"],
-    "description": "Webpack is an open-source JavaScript module bundler. It is a module bundler primarily for JavaScript, but it can transform front-end assets like HTML, CSS, and images if the corresponding loaders are included.",
-    "language": "JavaScript"
-  },
-  "Wpf": {
-    "imports": ["System.Windows"],
-    "technologies": ["Desktop applications"],
-    "description": "Windows Presentation Foundation (WPF) is a UI framework for building Windows desktop applications. WPF supports a broad set of application development features, including an application model, resources, controls, graphics, layout, data binding and documents.",
-    "language": "C#"
-  },
-  "XUnit.NET": {
-    "imports": ["XUnit"],
-    "technologies": ["Testing"],
-    "description": "xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework.",
-    "image": "https://avatars2.githubusercontent.com/u/2092016?s=200&v=4",
-    "language": "C#"
-  },
-  "Yii": {
-    "imports": ["yii\\", "yiisoft/yii"],
-    "technologies": ["Web Development", "PHP Frameworks", "MVC"],
-    "description": "Yii is a fast, secure, and efficient PHP framework.",
-    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/yii/yii.png",
-    "language": "PHP"
-  },
-  "Yii2": {
-    "imports": ["yii\\", "yiisoft/yii2"],
-    "technologies": ["Web Development", "PHP Frameworks", "MVC"],
-    "description": "Yii2 is a fast, secure, and efficient PHP framework.",
-    "image": "https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/yii/yii.png",
-    "language": "PHP"
+  "CSS":{
+    "Bootstrap":{
+      "imports":[
+        "bootstrap.css",
+        "boostrap.min.css"
+      ],
+      "technologies":[
+        "Frontend",
+        "CSS frameworks"
+      ],
+      "description":"Bootstrap is an open source toolkit for developing with HTML, CSS, and JS.",
+      "image":"https://mdbootstrap.com/img/logo/brands/bootstrap.jpg"
+    },
+    "Bulma":{
+      "imports":[
+        "bulma.css"
+      ],
+      "technologies":[
+        "Frontend",
+        "CSS frameworks"
+      ],
+      "description":"Bulma is a free, open source CSS framework based on Flexbox and used by more than 200,000 developers.",
+      "language":"CSS"
+    },
+    "Emotion":{
+      "imports":[
+        "@emotion/"
+      ],
+      "technologies":[
+        "Frontend",
+        "CSS frameworks"
+      ],
+      "description":"Emotion is a library designed for writing css styles with JavaScript."
+    },
+    "Glamorous":{
+      "imports":[
+        "glamorous"
+      ],
+      "technologies":[
+        "Frontend",
+        "CSS frameworks"
+      ],
+      "description":"Maintainable CSS with React."
+    },
+    "Materialize CSS":{
+      "imports":[
+        "materialize.min.css",
+        "materialize.css"
+      ],
+      "technologies":[
+        "CSS frameworks"
+      ],
+      "description":"A modern responsive front-end framework based on Material Design"
+    },
+    "PatternFly":{
+      "imports":[
+        "@patternfly/patternfly"
+      ],
+      "technologies":[
+        "Frontend",
+        "CSS frameworks"
+      ],
+      "description":"PatternFly is an open source design system created to enable consistency and usability across a wide range of applications and use cases.",
+      "image":"https://i.github-camo.com/8b1315539cf8078c2d44644f312d8e0f09225361/68747470733a2f2f7777772e7061747465726e666c792e6f72672f6173736574732f696d672f7061747465726e666c792d6f72622e737667"
+    },
+    "Radium":{
+      "imports":[
+        "radium"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "CSS Frameworks"
+      ],
+      "description":"A set of tools to manage inline styles on React elements, giving you powerful styling capabilities without CSS"
+    },
+    "Semantic UI":{
+      "imports":[
+        "semantic.min.css",
+        "semantic.css"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA"
+      ],
+      "description":"User Interface is the language of the web."
+    }
+  },
+  "C#":{
+    "ASP.NET":{
+      "imports":[
+        "Microsoft.AspNetCore.Mvc"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Server side rendering"
+      ],
+      "description":"ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends."
+    },
+    "Blazor":{
+      "imports":[
+        "Microsoft.AspNetCore.Components.Web"
+      ],
+      "technologies":[
+        "Frontend",
+        "WebAssembly"
+      ],
+      "description":"Blazor is a framework for building interactive client-side web UI with .NET",
+      "image":"https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2019/04/BrandBlazor_nohalo_1000x.png"
+    },
+    "Entity Framework":{
+      "imports":[
+        "Microsoft.EntityFrameworkCore"
+      ],
+      "technologies":[
+        "ORM"
+      ],
+      "description":"Entity Framework Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations."
+    },
+    "NUnit":{
+      "imports":[
+        "NUnit.Framework"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"NUnit is a unit-testing framework for all .Net languages.",
+      "image":"https://nunit.org/img/nunit_logo_128.png"
+    },
+    "Unity3D":{
+      "imports":[
+        "UnityEngine"
+      ],
+      "technologies":[
+        "Game Development"
+      ],
+      "description":"Unity is a real-time 3D development platform for creating games and other 3D graphics."
+    },
+    "Wpf":{
+      "imports":[
+        "System.Windows"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Windows Presentation Foundation (WPF) is a UI framework for building Windows desktop applications. WPF supports a broad set of application development features, including an application model, resources, controls, graphics, layout, data binding and documents."
+    },
+    "XUnit.NET":{
+      "imports":[
+        "XUnit"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework.",
+      "image":"https://avatars2.githubusercontent.com/u/2092016?s=200&v=4"
+    }
+  },
+  "Dart":{
+    "Flutter":{
+      "imports":[
+        "package:flutter"
+      ],
+      "technologies":[
+        "Mobile Development"
+      ],
+      "description":"Flutter is Google's UI toolkit for crafting beautiful, natively compiled applications for mobile, web, and desktop from a single codebase.",
+      "image":"https://upload.wikimedia.org/wikipedia/commons/1/17/Google-flutter-logo.png"
+    }
+  },
+  "Go":{
+    "Echo":{
+      "imports":[
+        "github.com/labstack/echo"
+      ],
+      "technologies":[
+        "framework"
+      ],
+      "description":"High performance, minimalist Go web framework."
+    },
+    "Gin":{
+      "imports":[
+        "github.com/gin-gonic/gin"
+      ],
+      "technologies":[
+        "Web Development",
+        "Backend"
+      ],
+      "description":"Gin is a HTTP web framework written in Go (Golang).",
+      "image":"https://raw.githubusercontent.com/gin-gonic/logo/master/color.png"
+    },
+    "Go Micro":{
+      "imports":[
+        "github.com/micro/go-micro"
+      ],
+      "technologies":[
+        "microservice"
+      ],
+      "description":"Go Micro provides the core requirements for distributed systems development including RPC and Event driven communication."
+    },
+    "GORM":{
+      "imports":[
+        "github.com/jinzhu/gorm"
+      ],
+      "technologies":[
+        "ORM"
+      ],
+      "description":"GORM is a fully-featured ORM library for Golang supporting MySQL, SQLite3, PostgreSQL and Microsoft SQL Server."
+    },
+    "Ponzu":{
+      "imports":[
+        "github.com/ponzu-cms/ponzu"
+      ],
+      "technologies":[
+        "CMS"
+      ],
+      "description":"Headless CMS with automatic JSON API. Featuring auto-HTTPS from Let's Encrypt, HTTP/2 Server Push, and flexible server framework written in Go."
+    }
+  },
+  "Groovy":{
+    "Grails":{
+      "imports":[
+        "grails"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks"
+      ],
+      "description":"A powerful Groovy-based web application framework for the JVM built on top of Spring Boot",
+      "image":"https://raw.githubusercontent.com/apache/groovy-website/asf-site/site/src/site/assets/img/groovy-logo-colored.svg"
+    }
+  },
+  "Java":{
+    "Apache Spark":{
+      "imports":[
+        "org.apache.spark"
+      ],
+      "technologies":[
+        "Data Processing",
+        "Backend"
+      ],
+      "description":"Unified analytics engine for large-scale data processing.",
+      "image":"https://spark.apache.org/images/spark-logo-trademark.png"
+    },
+    "Gson":{
+      "imports":[
+        "com.google.gson"
+      ],
+      "technologies":[
+        "JSon"
+      ],
+      "description":"Gson is a Java library that can be used to convert Java Objects into their JSON representation.",
+      "image":"https://s.appbrain.com/static/202005201421235/blob/sdk-logos/google_gson.png"
+    },
+    "GWT":{
+      "imports":[
+        "com.google.gwt"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend"
+      ],
+      "description":"Development toolkit for building and optimizing complex browser-based applications..",
+      "image":"http://www.gwtproject.org/assets/build/img/navLogoBig.png"
+    },
+    "Hibernate":{
+      "imports":[
+        "org.hibernate"
+      ],
+      "technologies":[
+        "ORM"
+      ],
+      "description":"Domain model persistence and Data library for Java."
+    },
+    "Jakarta Server Faces (JSF)":{
+      "imports":[
+        "javax.faces",
+        "com.sun.faces"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Frontend",
+        "Backend"
+      ],
+      "description":"MVC framework for building user interfaces for web applications.",
+      "image":"https://jakarta.ee/images/jakarta/jakarta-ee-logo.svg"
+    },
+    "Jersey":{
+      "imports":[
+        "org.glassfish.jersey"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend",
+        "REST"
+      ],
+      "description":"Web services framework to create RESTful services.",
+      "image":"https://eclipse-ee4j.github.io/jersey.github.io/images/jersey_logo.png"
+    },
+    "JUnit":{
+      "imports":[
+        "org.junit",
+        "junit"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"JUnit is a unit-testing framework for Java.",
+      "image":"https://junit.org/junit4/images/junit-logo.png"
+    },
+    "LibGDX":{
+      "imports":[
+        "com.badlogic.gdx"
+      ],
+      "technologies":[
+        "Java Frameworks",
+        "Mobile Development",
+        "Game Development",
+        "Desktop Development",
+        "Desktop Applications",
+        "Mobile Applications"
+      ],
+      "description":"libGDX is a free and open-source game-development application framework written in the Java programming language with some C and C++ components for performance dependent code. It allows for the development of desktop and mobile games by using the same code base. It is cross-platform, supporting Windows, Linux, Mac OS X, Android, iOS, BlackBerry and web browsers with WebGL support.",
+      "image":"https://www.badlogicgames.com/wordpress/wp-content/uploads/2011/05/libGDX-RedGlossyNoReflection.png"
+    },
+    "Micronaut":{
+      "imports":[
+        "io.micronaut"
+      ],
+      "technologies":[
+        "Web Development",
+        "Microservices",
+        "Java Frameworks"
+      ],
+      "description":"Micronaut is a modern, JVM-based, full-stack framework for building modular, easily testable microservice and serverless applications.",
+      "image":"https://raw.githubusercontent.com/micronaut-projects/static-website/master/main/src/main/resources/assets/images/micronaut_mini.svg"
+    },
+    "Mockito":{
+      "imports":[
+        "org.mockito"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Mocking framework for unit tests in Java",
+      "image":"https://raw.githubusercontent.com/mockito/mockito.github.io/master/img/logo%402x.png"
+    },
+    "OkHttp":{
+      "imports":[
+        "com.squareup.okhttp"
+      ],
+      "technologies":[
+        "Mobile Development",
+        "Java Frameworks"
+      ],
+      "description":"OkHttp is an HTTP client that’s efficient by default: HTTP/2 support, reduces request latency... ."
+    },
+    "Okio":{
+      "imports":[
+        "com.squareup.okio"
+      ],
+      "technologies":[
+        "Mobile Development",
+        "Java Frameworks",
+        "Kotlin Frameworks"
+      ],
+      "description":"A modern I/O library for Android, Kotlin, and Java."
+    },
+    "Picasso":{
+      "imports":[
+        "com.squareup.picasso"
+      ],
+      "technologies":[
+        "Mobile Development"
+      ],
+      "description":"A powerful image downloading and caching library for Android."
+    },
+    "Retrofit":{
+      "imports":[
+        "com.squareup.retrofit"
+      ],
+      "technologies":[
+        "Mobile Development",
+        "Java Frameworks"
+      ],
+      "description":"A type-safe HTTP client for Android and Java."
+    },
+    "RxJava":{
+      "imports":[
+        "io.reactivex"
+      ],
+      "technologies":[
+        "Web Development",
+        "Mobile Development"
+      ],
+      "description":"Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM"
+    },
+    "Rex":{
+      "imports":[
+        "Rex"
+      ],
+      "technologies":[
+        "Automation",
+        "DevOps"
+      ],
+      "description":"Rex, the friendly automation framework.",
+      "image":"https://www.rexify.org/public/images/skin/rexify.org/favicon.png"
+    },
+    "SLF4J":{
+      "imports":[
+        "org.slf4j"
+      ],
+      "technologies":[
+        "Logging"
+      ],
+      "description":"Simple facade or abstraction for various logging frameworks.",
+      "image":"http://www.slf4j.org/images/logos/slf4j-logo.jpg"
+    },
+    "Spark Java":{
+      "imports":[
+        "spark"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend"
+      ],
+      "description":"A micro framework for creating web applications with minimal effort.",
+      "image":"http://sparkjava.com/img/logo.svg"
+    },
+    "Spring":{
+      "imports":[
+        "org.springframework"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend"
+      ],
+      "description":"Comprehensive programming and configuration model for modern Java-based enterprise applications.",
+      "image":"https://spring.io/images/spring-logo-9146a4d3298760c2e7e49595184e1975.svg"
+    },
+    "Spring Boot":{
+      "imports":[
+        "org.springframework.boot"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend"
+      ],
+      "description":"Bootstrap a Spring application with little or no configuration.",
+      "image":"https://spring.io/images/spring-logo-9146a4d3298760c2e7e49595184e1975.svg"
+    },
+    "Struts":{
+      "imports":[
+        "org.apache.struts2",
+        "org.apache.struts"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Frontend",
+        "Backend"
+      ],
+      "description":"MVC framework for creating elegant, modern Java web applications.",
+      "image":"https://struts.apache.org/img/struts-logo.svg"
+    },
+    "Vaadin":{
+      "imports":[
+        "com.vaadin"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Frontend",
+        "Backend"
+      ],
+      "description":"Full stack framework for building web apps in Java.",
+      "image":"https://vaadin.com/images/vaadin-logo.svg"
+    },
+    "Vert.x":{
+      "imports":[
+        "io.vertx"
+      ],
+      "technologies":[
+        "Web Development",
+        "Java Frameworks",
+        "Backend"
+      ],
+      "description":"Tool-kit for building reactive applications on the JVM.",
+      "image":"https://vertx.io/assets/logo-sm.png"
+    }
+  },
+  "JavaScript":{
+    "AfterJS":{
+      "imports":[
+        "@jaredpalmer/after"
+      ],
+      "technologies":[
+        "Server side rendering"
+      ],
+      "description":"After.js enables Next.js-like data fetching with any React SSR app that uses React Router 4."
+    },
+    "Angular Universal":{
+      "imports":[
+        "@nguniversal/"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Server side rendering"
+      ],
+      "description":"A technology that renders Angular applications on the server."
+    },
+    "AngularJS":{
+      "imports":[
+        "angular"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "SPA"
+      ],
+      "description":"AngularJS is a predecessor of Angular, an open source web application platform.",
+      "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png"
+    },
+    "AnimeJS":{
+      "imports":[
+        "anime.js"
+      ],
+      "technologies":[
+        "Frontend",
+        "Animation"
+      ],
+      "description":"Anime.js is a lightweight JavaScript animation library with a simple, yet powerful API. It works with CSS properties, SVG, DOM attributes and JavaScript Objects.",
+      "image":"https://animejs.com/documentation/assets/img/anime-mini-logo.svg"
+    },
+    "BabylonJS":{
+      "imports":[
+        "babylonjs"
+      ],
+      "technologies":[
+        "WebGL"
+      ],
+      "description":"Powerful, beautiful, simple, open, web-based 3D at its best"
+    },
+    "Carlo":{
+      "imports":[
+        "carlo"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Carlo provides Node applications with Google Chrome rendering capabilities, communicates with the locally-installed browser instance using the Puppeteer project, and implements a remote call infrastructure for communication between Node and the browser."
+    },
+    "Chai":{
+      "imports":[
+        "chai"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Chai is a BDD / TDD assertion library for Node.js and the browser.",
+      "image":"https://www.chaijs.com/img/chai-logo.png"
+    },
+    "ChartJS":{
+      "imports":[
+        "chart.js"
+      ],
+      "technologies":[
+        "Frontend",
+        "Data Visualization"
+      ],
+      "description":"A simple yet flexible Javascript charting library for Designers and Developers.",
+      "image":"https://www.chartjs.org/media/logo-title.svg"
+    },
+    "Cypress":{
+      "imports":[
+        "cypress"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Cypress is a Javascript End to End testing framework"
+    },
+    "D3":{
+      "imports":[
+        "d3"
+      ],
+      "technologies":[
+        "Frontend",
+        "Data Visualization"
+      ],
+      "description":"D3 (or D3.js) is a JavaScript library for visualizing data using web standards. D3 helps you bring data to life using SVG, Canvas and HTML DOM manipulation.",
+      "image":"https://d3js.org/logo.svg"
+    },
+    "Effector":{
+      "imports":[
+        "effector"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA"
+      ],
+      "description":"Effective multi-store state manager for Javascript apps"
+    },
+    "Electron":{
+      "imports":[
+        "electron"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Build cross platform desktop apps with JavaScript, HTML, and CSS"
+    },
+    "Enzyme":{
+      "imports":[
+        "enzyme"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Enzyme is a JavaScript Testing utility for React that makes it easier to test your React Components' output"
+    },
+    "ExpressJS":{
+      "imports":[
+        "express"
+      ],
+      "technologies":[
+        "Web Development",
+        "JavaScript Frameworks",
+        "Backend"
+      ],
+      "description":"Express is a minimal Node.js framework for web.",
+      "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/express/express.png"
+    },
+    "Flow":{
+      "imports":[
+        "flowjs"
+      ],
+      "_comment":"This is a special keyword, see repo info extractor JavaScript parser",
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Flow is a static type checker for JavaScript, it works in a similar way that a linter does."
+    },
+    "Framework7":{
+      "imports":[
+        "framework7"
+      ],
+      "technologies":[
+        "Mobile applications",
+        "Desktop applications",
+        "Progressive Web Apps",
+        "CSS frameworks"
+      ],
+      "description":"A free and open source framework to develop mobile, desktop or web apps with native look and feel"
+    },
+    "GraphQL":{
+      "imports":[
+        "graphql-express",
+        "graphql"
+      ],
+      "technologies":[
+        "Web Development",
+        "JavaScript Frameworks"
+      ],
+      "description":"A query language for your API",
+      "image":"https://uploads.getpop.org/wp-content/uploads/2019/07/graphql-480x480.png"
+    },
+    "Gulp":{
+      "imports":[
+        "gulp"
+      ],
+      "technologies":[
+        "Build tools"
+      ],
+      "description":"Gulp is an open-source JavaScript toolkit created by Eric Schoffstall used as a streaming build system in front-end web development."
+    },
+    "Hapi":{
+      "imports":[
+        "@hapi/",
+        "hapi"
+      ],
+      "technologies":[
+        "Web Development",
+        "JavaScript Frameworks",
+        "Backend"
+      ],
+      "description":"Hapi is a simple, secure web framework for Node.js.",
+      "image":"https://raw.githubusercontent.com/hapijs/assets/master/images/hapi.png"
+    },
+    "Impress":{
+      "imports":[
+        "impress"
+      ],
+      "technologies":[
+        "Backend",
+        "Private Cloud",
+        "Application Server"
+      ],
+      "description":"Application Server for Node.js Private Cloud",
+      "image":"https://github.com/metarhia/Metarhia/blob/master/Logos/impress-with-text.svg"
+    },
+    "Ionic":{
+      "imports":[
+        "@ionic/"
+      ],
+      "technologies":[
+        "Mobile applications"
+      ],
+      "description":"Ionic is the app development platform for web developers"
+    },
+    "Jest":{
+      "imports":[
+        "jest"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Jest is a delightful JavaScript Testing Framework with a focus on simplicity"
+    },
+    "KiwiJS":{
+      "imports":[
+        "kiwi-js"
+      ],
+      "technologies":[
+        "Web Development",
+        "Mobile Development",
+        "Game Development"
+      ],
+      "description":"Kiwi.js is a mobile first HTML5 and Javascript game engine supporting both Canvas and WebGL rendering.",
+      "image":"http://www.kiwijs.org/wp-content/themes/kiwijs/assets/logo.png"
+    },
+    "Koa":{
+      "imports":[
+        "koa"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Next generation web framework for Node.js",
+      "image":"https://raw.githubusercontent.com/koajs/koa/f3ede44ffa6b59dcdc4d94d1faaa223aa6c60a51/docs/logo.png"
+    },
+    "Material UI":{
+      "imports":[
+        "@material-ui"
+      ],
+      "technologies":[
+        "Frontend"
+      ],
+      "description":"React components for faster and easier web development.",
+      "image":"https://material-ui.com/static/logo_raw.svg"
+    },
+    "MeteorJS":{
+      "imports":[
+        "meteor"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Full Stack"
+      ],
+      "description":"Meteor.js is a full stack framework. It means that you can control everything from the database to the UI with the same language and the same framework, and it is one of Meteor’s primary advantages.",
+      "image":"https://user-images.githubusercontent.com/841294/26841702-0902bbee-4af3-11e7-9805-0618da66a246.png"
+    },
+    "MobX":{
+      "imports":[
+        "mobx"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA"
+      ],
+      "description":"MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP)"
+    },
+    "NativeScript":{
+      "imports":[
+        "nativescript"
+      ],
+      "technologies":[
+        "Mobile applications"
+      ],
+      "description":"Open source framework for building truly native mobile apps with Angular, Vue.js, TypeScript, or JavaScript."
+    },
+    "NativeScriptVue":{
+      "imports":[
+        "nativescript-vue"
+      ],
+      "technologies":[
+        "Mobile applications",
+        "JavaScript Frameworks"
+      ],
+      "description":"Open source framework for building truly native mobile apps with Vue.js.",
+      "image":"https://art.nativescript-vue.org/NativeScript-Vue-White-Green.svg"
+    },
+    "Neo4j":{
+      "imports":[
+        "neo4j",
+        "neo4j-driver"
+      ],
+      "technologies":[
+        "Java",
+        "JavaScript",
+        "Databases"
+      ],
+      "description":"Neo4j is a graph database management system developed by Neo4j, Inc.",
+      "image":"https://go.neo4j.com/rs/710-RRC-335/images/neo4j_logo_globe.png"
+    },
+    "NextJS":{
+      "imports":[
+        "nextjs"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Server side rendering"
+      ],
+      "description":"Production grade React applications that scale. The world's leading companies use Next.js to build server-rendered applications, static websites, and more."
+    },
+    "NodeJS":{
+      "imports":[
+        "child_process",
+        "cluster",
+        "crypto",
+        "dns",
+        "events",
+        "fs",
+        "http",
+        "http2",
+        "https",
+        "net",
+        "os",
+        "path",
+        "stream",
+        "tls",
+        "udp",
+        "url",
+        "util",
+        "v8",
+        "vm",
+        "worker_threads",
+        "zlib"
+      ],
+      "technologies":[
+        "Frontend",
+        "Backend"
+      ],
+      "description":"JavaScript runtime built on V8 engine and libuv",
+      "image":"https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg"
+    },
+    "NuxtJS":{
+      "imports":[
+        "nuxtjs"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Server side rendering"
+      ],
+      "description":"Nuxt.js is a free and open source web application framework based on Vue.js, Node.js, Webpack and Babel.js."
+    },
+    "Parcel":{
+      "imports":[
+        "parcel"
+      ],
+      "technologies":[
+        "Build tools"
+      ],
+      "description":"Blazing fast, zero configuration web application bundler."
+    },
+    "Proton Native":{
+      "imports":[
+        "proton-native"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Create native desktop applications through a React syntax, on all platforms"
+    },
+    "React Native":{
+      "imports":[
+        "react-native"
+      ],
+      "technologies":[
+        "Mobile applications"
+      ],
+      "description":"React Native combines the best parts of native development with React, a best-in-class JavaScript library for building user interfaces."
+    },
+    "ReactJS":{
+      "imports":[
+        "react"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "SPA",
+        "JavaScript Frameworks"
+      ],
+      "description":"A JavaScript library for building user interfaces",
+      "image":"https://cdn4.iconfinder.com/data/icons/logos-3/600/React.js_logo-512.png"
+    },
+    "Redux":{
+      "imports":[
+        "redux"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"A predictable state container for JavaScript apps."
+    },
+    "Redux Saga":{
+      "imports":[
+        "redux-saga"
+      ],
+      "technologies":[
+        "Web Development",
+        "Frontend"
+      ],
+      "description":"An alternative side effect model for Redux apps."
+    },
+    "Rollup":{
+      "imports":[
+        "rollup"
+      ],
+      "technologies":[
+        "Build tools"
+      ],
+      "description":"Parcel is a web application bundler, differentiated by its developer experience. It offers blazing fast performance utilizing multicore processing, and requires zero configuration."
+    },
+    "RxJS":{
+      "imports":[
+        "rxjs"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Reactive Extensions Library for JavaScript"
+    },
+    "Sequelize":{
+      "imports":[
+        "sequelize"
+      ],
+      "technologies":[
+        "ORM",
+        "NodeJS"
+      ],
+      "description":"Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server.",
+      "image":"https://avatars1.githubusercontent.com/u/3591786"
+    },
+    "Socket.io":{
+      "imports":[
+        "socket.io"
+      ],
+      "technologies":[
+        "Websockets"
+      ],
+      "description":"Featuring the fastest and most reliable real-time engine."
+    },
+    "Styled Components":{
+      "imports":[
+        "styled-components"
+      ],
+      "technologies":[
+        "Frontend"
+      ],
+      "description":"Styled components is a way to write modular CSS in modern JavaScript."
+    },
+    "Svelte":{
+      "imports":[
+        "svelte"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA"
+      ],
+      "description":"Svelte is a radical new approach to building user interfaces. Whereas traditional frameworks like React and Vue do the bulk of their work in the browser, Svelte shifts that work into a compile step that happens when you build your app.",
+      "image":"https://raw.githubusercontent.com/sveltejs/branding/master/svelte-logo.png"
+    },
+    "ThreeJS":{
+      "imports":[
+        "three"
+      ],
+      "technologies":[
+        "WebGL"
+      ],
+      "description":"Three.js is a cross-browser JavaScript library and Application Programming Interface used to create and display animated 3D computer graphics in a web browser."
+    },
+    "VueJS":{
+      "imports":[
+        "vue"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "SPA",
+        "JavaScript Frameworks"
+      ],
+      "description":"The Progressive JavaScript Framework",
+      "image":"https://raw.githubusercontent.com/vuejs/art/master/logo.png"
+    },
+    "VueX":{
+      "imports":[
+        "vuex"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "JavaScript Frameworks"
+      ],
+      "description":"Centralized State Management for Vue.js."
+    },
+    "Webpack":{
+      "imports":[
+        "webpack"
+      ],
+      "technologies":[
+        "Build tools"
+      ],
+      "description":"Webpack is an open-source JavaScript module bundler. It is a module bundler primarily for JavaScript, but it can transform front-end assets like HTML, CSS, and images if the corresponding loaders are included."
+    }
+  },
+  "OpenEdge ABL":{
+    "OpenEdge ABL":{
+      "imports":[
+        "OpenEdge"
+      ],
+      "technologies":[
+        "Desktop Applications",
+        "Web Development",
+        "Databases"
+      ],
+      "description":"Business application development language created and maintained by Progress Software Corporation"
+    },
+    "SpeedScript":{
+      "imports":[
+        "OpenEdge"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"SpeedScript is a subset of OpenEdge ABL language used in the development of web applications"
+    }
+  },
+  "Perl":{
+    "CHI":{
+      "imports":[
+        "CHI"
+      ],
+      "technologies":[
+        "Scalability"
+      ],
+      "description":"Unified cache handling interface."
+    },
+    "Dancer":{
+      "imports":[
+        "Dancer"
+      ],
+      "technologies":[
+        "Web Development",
+        "MVC"
+      ],
+      "description":"Lightweight yet powerful web application framework.",
+      "image":"http://perldancer.org/images/dcr-header-logo.png"
+    },
+    "DBI":{
+      "imports":[
+        "DBI",
+        "DBD"
+      ],
+      "technologies":[
+        "Databases"
+      ],
+      "description":"Database independent interface for Perl."
+    },
+    "DBIx::Class":{
+      "imports":[
+        "DBIx::Class"
+      ],
+      "technologies":[
+        "ORM"
+      ],
+      "description":"Extensible and flexible object <-> relational mapper."
+    },
+    "IO::Async":{
+      "imports":[
+        "IO::Async"
+      ],
+      "technologies":[
+        "Async Programming"
+      ],
+      "description":"Asynchronous event-driven programming."
+    },
+    "Log::Log4perl":{
+      "imports":[
+        "Log::Log4perl"
+      ],
+      "technologies":[
+        "Logging"
+      ],
+      "description":"Log4j implementation for Perl."
+    },
+    "MCE":{
+      "imports":[
+        "MCE"
+      ],
+      "technologies":[
+        "Parallel Computing"
+      ],
+      "description":"Many-Core Engine for Perl providing parallel processing capabilities."
+    },
+    "Mojolicious":{
+      "imports":[
+        "Mojolicious"
+      ],
+      "technologies":[
+        "Web Development",
+        "MVC"
+      ],
+      "description":"Real-time web framework.",
+      "image":"https://mojolicious.org/favicon.ico"
+    },
+    "Moo":{
+      "imports":[
+        "Moo"
+      ],
+      "technologies":[
+        "Object Oriented Programming"
+      ],
+      "description":"Minimalist Object Orientation."
+    },
+    "Moose":{
+      "imports":[
+        "Moose"
+      ],
+      "technologies":[
+        "Object Oriented Programming"
+      ],
+      "description":"A postmodern object system for Perl 5."
+    },
+    "Parallel::ForkManager":{
+      "imports":[
+        "Parallel::ForkManager"
+      ],
+      "technologies":[
+        "Parallel Computing"
+      ],
+      "description":"A simple parallel processing fork manager."
+    },
+    "POE":{
+      "imports":[
+        "POE"
+      ],
+      "technologies":[
+        "Async Programming"
+      ],
+      "description":"Portable multitasking and networking framework for any event loop."
+    },
+    "Test2":{
+      "imports":[
+        "Test2"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Framework for writing test tools that all work together."
+    },
+    "Test::Simple":{
+      "imports":[
+        "Test::Simple",
+        "Test::More"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Basic utilities for writing tests."
+    }
+  },
+  "PHP":{
+    "Laravel":{
+      "imports":[
+        "Illuminate\\",
+        "laravel/laravel",
+        "laravel/framework"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks",
+        "MVC"
+      ],
+      "description":"A PHP framework for web artisans.",
+      "image":"https://user-images.githubusercontent.com/10347617/73778440-479a8280-479c-11ea-8446-1ab4b0f5c7fd.png"
+    },
+    "Phalcon":{
+      "imports":[
+        "Phalcon\\"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks"
+      ],
+      "description":"High performance, full-stack PHP framework delivered as a C extension.",
+      "image":"https://raw.githubusercontent.com/phalcon/assets/master/phalcon/images/svg/phalcon-logo-300x300.svg"
+    },
+    "Pimcore":{
+      "imports":[
+        "Pimcore\\",
+        "pimcore/pimcore"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks",
+        "CMS"
+      ],
+      "description":"Open Source Digital Experience Platform: MDM/PIM, CDP, DAM, CMS/UX and eCommerce",
+      "image":"https://github.com/pimcore/pimcore/raw/master/doc/Development_Documentation/img/logo-readme.svg"
+    },
+    "ReactPHP":{
+      "imports":[
+        "React\\",
+        "react/react"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"ReactPHP is a low-level library for event-driven programming in PHP.",
+      "image":"https://avatars3.githubusercontent.com/u/1696866"
+    },
+    "Symfony":{
+      "imports":[
+        "Symfony\\",
+        "symfony/symfony"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks",
+        "MVC"
+      ],
+      "description":"Symfony, High Performance PHP Framework for Web Development.",
+      "image":"https://avatars0.githubusercontent.com/u/143937"
+    },
+    "Yii":{
+      "imports":[
+        "yii\\",
+        "yiisoft/yii"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks",
+        "MVC"
+      ],
+      "description":"Yii is a fast, secure, and efficient PHP framework.",
+      "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/yii/yii.png"
+    },
+    "Yii2":{
+      "imports":[
+        "yii\\",
+        "yiisoft/yii2"
+      ],
+      "technologies":[
+        "Web Development",
+        "PHP Frameworks",
+        "MVC"
+      ],
+      "description":"Yii2 is a fast, secure, and efficient PHP framework.",
+      "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/yii/yii.png"
+    }
+  },
+  "Python":{
+    "Behave":{
+      "imports":[
+        "behave"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Behave is behaviour-driven development, Python style.",
+      "image":"https://camo.githubusercontent.com/cf89b9309dfd7ca1fa954bdd7f63ca29b6c4497c/68747470733a2f2f7261772e6769746875622e636f6d2f6265686176652f6265686176652f6d61737465722f646f63732f5f7374617469632f6265686176655f6c6f676f312e706e67"
+    },
+    "Django":{
+      "imports":[
+        "django"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Django is a high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+    },
+    "Django REST framework":{
+      "imports":[
+        "rest_framework"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Django REST framework is a powerful and flexible toolkit for building Web APIs."
+    },
+    "Flask":{
+      "imports":[
+        "flask"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Flask is a lightweight WSGI web application framework. It is designed to make getting started quick and easy, with the ability to scale up to complex applications."
+    },
+    "Graphene":{
+      "imports":[
+        "graphene"
+      ],
+      "technologies":[
+        "Web Development",
+        "Python Library"
+      ],
+      "description":"GraphQL in Python Made Easy.",
+      "image":"https://avatars2.githubusercontent.com/u/15002022?s=200&v=4"
+    },
+    "Keras":{
+      "imports":[
+        "keras",
+        "tensorflow.keras"
+      ],
+      "technologies":[
+        "Machine Learning",
+        "Deep Learning",
+        "Backend"
+      ],
+      "description":"Keras is a deep learning API written in Python, running on top of the machine learning platform TensorFlow. It was developed with a focus on enabling fast experimentation. Being able to go from idea to result as fast as possible is key to doing good research.",
+      "image":"https://keras.io/img/logo.png"
+    },
+    "Kivy":{
+      "imports":[
+        "kivy"
+      ],
+      "technologies":[
+        "Desktop applications",
+        "Mobile applications"
+      ],
+      "description":"Kivy - Open source Python library for rapid development of applications that make use of innovative user interfaces, such as multi-touch apps.",
+      "image":"https://kivy.org/logos/kivy-logo-black-256.png"
+    },
+    "Matplotlib":{
+      "imports":[
+        "matplotlib"
+      ],
+      "technologies":[
+        "Data Visualization"
+      ],
+      "description":"Matplotlib is a comprehensive library for creating static, animated, and interactive visualizations in Python.",
+      "image":"https://matplotlib.org/_static/logo2_compressed.svg"
+    },
+    "NumPy":{
+      "imports":[
+        "numpy"
+      ],
+      "technologies":[
+        "Scientific Computing",
+        "Data Processing",
+        "Data Science"
+      ],
+      "description":"The fundamental package for scientific computing with Python.",
+      "image":"https://numpy.org/images/logos/numpy.svg"
+    },
+    "Pandas":{
+      "imports":[
+        "pandas"
+      ],
+      "technologies":[
+        "Scientific Computing",
+        "Data Processing",
+        "Data Science",
+        "Data Analysis"
+      ],
+      "description":"Pandas is a fast, powerful, flexible and easy to use open source data analysis and manipulation tool, built on top of the Python programming language.",
+      "image":"https://pandas.pydata.org/static/img/pandas_white.svg"
+    },
+    "Pygame":{
+      "imports":[
+        "pygame"
+      ],
+      "technologies":[
+        "Desktop applications",
+        "Game development"
+      ],
+      "description":"Pygame is a cross-platform set of Python modules designed for writing video games. It includes computer graphics and sound libraries designed to be used with the Python programming language.",
+      "image":"http://www.pygame.org/docs/pygame_small.gif"
+    },
+    "Pyglet":{
+      "imports":[
+        "pyglet"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Pyglet is a cross-platform windowing and multimedia library for Python, intended for developing games and other visually rich applications.",
+      "image":"https://pyglet.readthedocs.io/en/stable/_static/logo.png"
+    },
+    "PyQt":{
+      "imports":[
+        "PyQt5",
+        "PyQt4"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"PyQt is one of the most popular Python bindings for the Qt cross-platform C++ framework"
+    },
+    "Pyramid":{
+      "imports":[
+        "pyramid"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"Pyramid makes it easy to write web applications. You can start small with this \"hello world\" minimal request/response web app. This may take you far, especially while learning. As your application grows, Pyramid offers many features that make writing complex software take less effort.",
+      "image":"https://trypyramid.com/img/pyramid-60x60.png"
+    },
+    "Pytest":{
+      "imports":[
+        "pytest"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"Pytest is a framework that makes building simple and scalable tests easy.",
+      "image":"https://docs.pytest.org/en/stable/_static/pytest1.png"
+    },
+    "Tensorflow":{
+      "imports":[
+        "tensorflow"
+      ],
+      "technologies":[
+        "Machine Learning",
+        "Deep Learning",
+        "Backend"
+      ],
+      "description":"TensorFlow is an end-to-end open source platform for machine learning. It has a comprehensive, flexible ecosystem of tools, libraries and community resources that lets researchers push the state-of-the-art in ML and developers easily build and deploy ML powered applications.",
+      "image":"https://www.gstatic.com/devrel-devsite/prod/vbbb6dd37c071e57dbfce1249762e4d342b93b36af15e7676b1059db22e43eb43/tensorflow/images/lockup.svg?dcb_=0.830285463447934"
+    },
+    "Twisted":{
+      "imports":[
+        "twisted"
+      ],
+      "technologies":[
+        "Web Development",
+        "Backend"
+      ],
+      "description":"Event-based framework for internet applications, supporting Python 3.5+.",
+      "image":"https://www.twistedmatrix.com/trac/chrome/common/trac_banner.png"
+    }
+  },
+  "Ruby":{
+    "Rails":{
+      "imports":[
+        "rails"
+      ],
+      "technologies":[
+        "Web Development",
+        "MVC"
+      ],
+      "description":"Rails is a web application development framework written in the Ruby programming language. It is designed to make programming web applications easier by making assumptions about what every developer needs to get started.",
+      "image":"https://upload.wikimedia.org/wikipedia/commons/6/62/Ruby_On_Rails_Logo.svg"
+    }
+  },
+  "TypeScript":{
+    "Angular":{
+      "imports":[
+        "@angular/",
+        "angular2"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "SPA"
+      ],
+      "description":"Angular is an open source web application platform.",
+      "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png"
+    },
+    "NestJS":{
+      "imports":[
+        "@nestjs/"
+      ],
+      "technologies":[
+        "Web Development"
+      ],
+      "description":"A progressive Node.js framework for building efficient, reliable and scalable server-side applications.",
+      "image":"https://nestjs.com/img/logo-small.svg"
+    },
+    "NgRx":{
+      "imports":[
+        "@ngrx"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA"
+      ],
+      "description":"RxJS powered state management for Angular applications, inspired by Redux"
+    },
+    "Ts.ED":{
+      "imports":[
+        "@tsed/"
+      ],
+      "technologies":[
+        "Web Development",
+        "MVC"
+      ],
+      "description":"A Node.js and TypeScript Framework on top of ExpressJS."
+    }
   }
 }

--- a/libraries.json
+++ b/libraries.json
@@ -1543,6 +1543,16 @@
       ],
       "description":"PyMongo - the Python driver for MongoDB"
     },
+    "PyMySQL":{
+      "imports":[
+        "PyMySQL"
+      ],
+      "technologies":[
+        "Databases",
+        "MySQL"
+      ],
+      "description":"Pure Python MySQL Client"
+    },
     "PyQt":{
       "imports":[
         "PyQt5",

--- a/libraries.json
+++ b/libraries.json
@@ -11,6 +11,77 @@
       "description":"MongoDB object modeling designed to work in an asynchronous environment."
     }
   },
+  "C#":{
+    "ASP.NET":{
+      "imports":[
+        "Microsoft.AspNetCore.Mvc"
+      ],
+      "technologies":[
+        "Web Development",
+        "SPA",
+        "Server side rendering"
+      ],
+      "description":"ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends."
+    },
+    "Blazor":{
+      "imports":[
+        "Microsoft.AspNetCore.Components.Web"
+      ],
+      "technologies":[
+        "Frontend",
+        "WebAssembly"
+      ],
+      "description":"Blazor is a framework for building interactive client-side web UI with .NET",
+      "image":"https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2019/04/BrandBlazor_nohalo_1000x.png"
+    },
+    "Entity Framework":{
+      "imports":[
+        "Microsoft.EntityFrameworkCore"
+      ],
+      "technologies":[
+        "ORM"
+      ],
+      "description":"Entity Framework Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations."
+    },
+    "NUnit":{
+      "imports":[
+        "NUnit.Framework"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"NUnit is a unit-testing framework for all .Net languages.",
+      "image":"https://nunit.org/img/nunit_logo_128.png"
+    },
+    "Unity3D":{
+      "imports":[
+        "UnityEngine"
+      ],
+      "technologies":[
+        "Game Development"
+      ],
+      "description":"Unity is a real-time 3D development platform for creating games and other 3D graphics."
+    },
+    "Wpf":{
+      "imports":[
+        "System.Windows"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Windows Presentation Foundation (WPF) is a UI framework for building Windows desktop applications. WPF supports a broad set of application development features, including an application model, resources, controls, graphics, layout, data binding and documents."
+    },
+    "XUnit.NET":{
+      "imports":[
+        "XUnit"
+      ],
+      "technologies":[
+        "Testing"
+      ],
+      "description":"xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework.",
+      "image":"https://avatars2.githubusercontent.com/u/2092016?s=200&v=4"
+    }
+  },
   "CSS":{
     "Bootstrap":{
       "imports":[
@@ -99,77 +170,6 @@
       "description":"User Interface is the language of the web."
     }
   },
-  "C#":{
-    "ASP.NET":{
-      "imports":[
-        "Microsoft.AspNetCore.Mvc"
-      ],
-      "technologies":[
-        "Web Development",
-        "SPA",
-        "Server side rendering"
-      ],
-      "description":"ASP.NET Core is an open-source and cross-platform framework for building modern cloud based internet connected applications, such as web apps, IoT apps and mobile backends."
-    },
-    "Blazor":{
-      "imports":[
-        "Microsoft.AspNetCore.Components.Web"
-      ],
-      "technologies":[
-        "Frontend",
-        "WebAssembly"
-      ],
-      "description":"Blazor is a framework for building interactive client-side web UI with .NET",
-      "image":"https://devblogs.microsoft.com/aspnet/wp-content/uploads/sites/16/2019/04/BrandBlazor_nohalo_1000x.png"
-    },
-    "Entity Framework":{
-      "imports":[
-        "Microsoft.EntityFrameworkCore"
-      ],
-      "technologies":[
-        "ORM"
-      ],
-      "description":"Entity Framework Core is a modern object-database mapper for .NET. It supports LINQ queries, change tracking, updates, and schema migrations."
-    },
-    "NUnit":{
-      "imports":[
-        "NUnit.Framework"
-      ],
-      "technologies":[
-        "Testing"
-      ],
-      "description":"NUnit is a unit-testing framework for all .Net languages.",
-      "image":"https://nunit.org/img/nunit_logo_128.png"
-    },
-    "Unity3D":{
-      "imports":[
-        "UnityEngine"
-      ],
-      "technologies":[
-        "Game Development"
-      ],
-      "description":"Unity is a real-time 3D development platform for creating games and other 3D graphics."
-    },
-    "Wpf":{
-      "imports":[
-        "System.Windows"
-      ],
-      "technologies":[
-        "Desktop applications"
-      ],
-      "description":"Windows Presentation Foundation (WPF) is a UI framework for building Windows desktop applications. WPF supports a broad set of application development features, including an application model, resources, controls, graphics, layout, data binding and documents."
-    },
-    "XUnit.NET":{
-      "imports":[
-        "XUnit"
-      ],
-      "technologies":[
-        "Testing"
-      ],
-      "description":"xUnit.net is a free, open source, community-focused unit testing tool for the .NET Framework.",
-      "image":"https://avatars2.githubusercontent.com/u/2092016?s=200&v=4"
-    }
-  },
   "Dart":{
     "Flutter":{
       "imports":[
@@ -241,6 +241,17 @@
       ],
       "description":"MongoDB driver for Go"
     },
+    "pgx":{
+      "imports":[
+        "github.com/jackc/pgx/v4",
+        "github.com/jackc/pgx"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL Driver and Toolkit"
+    },
     "Ponzu":{
       "imports":[
         "github.com/ponzu-cms/ponzu"
@@ -259,17 +270,6 @@
         "PostgreSQL"
       ],
       "description":"A pure Go postgres driver for Go's database/sql package"
-    },
-    "pgx":{
-      "imports":[
-        "github.com/jackc/pgx/v4",
-        "github.com/jackc/pgx"
-      ],
-      "technologies":[
-        "Databases",
-        "PostgreSQL"
-      ],
-      "description":"PostgreSQL Driver and Toolkit"
     }
   },
   "Groovy":{
@@ -465,15 +465,6 @@
       ],
       "description":"A modern I/O library for Android, Kotlin, and Java."
     },
-    "Picasso":{
-      "imports":[
-        "com.squareup.picasso"
-      ],
-      "technologies":[
-        "Mobile Development"
-      ],
-      "description":"A powerful image downloading and caching library for Android."
-    },
     "PgJDBC":{
       "imports":[
         "org.postgresql"
@@ -483,6 +474,15 @@
         "PostgreSQL"
       ],
       "description":"PostgreSQL JDBC Driver (PgJDBC for short) allows Java programs to connect to a PostgreSQL database using standard, database independent Java code."
+    },
+    "Picasso":{
+      "imports":[
+        "com.squareup.picasso"
+      ],
+      "technologies":[
+        "Mobile Development"
+      ],
+      "description":"A powerful image downloading and caching library for Android."
     },
     "Retrofit":{
       "imports":[
@@ -494,16 +494,6 @@
       ],
       "description":"A type-safe HTTP client for Android and Java."
     },
-    "RxJava":{
-      "imports":[
-        "io.reactivex"
-      ],
-      "technologies":[
-        "Web Development",
-        "Mobile Development"
-      ],
-      "description":"Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM"
-    },
     "Rex":{
       "imports":[
         "Rex"
@@ -514,6 +504,16 @@
       ],
       "description":"Rex, the friendly automation framework.",
       "image":"https://www.rexify.org/public/images/skin/rexify.org/favicon.png"
+    },
+    "RxJava":{
+      "imports":[
+        "io.reactivex"
+      ],
+      "technologies":[
+        "Web Development",
+        "Mobile Development"
+      ],
+      "description":"Reactive Extensions for the JVM – a library for composing asynchronous and event-based programs using observable sequences for the Java VM"
     },
     "SLF4J":{
       "imports":[
@@ -664,15 +664,6 @@
       ],
       "description":"Powerful, beautiful, simple, open, web-based 3D at its best"
     },
-    "Carlo":{
-      "imports":[
-        "carlo"
-      ],
-      "technologies":[
-        "Desktop applications"
-      ],
-      "description":"Carlo provides Node applications with Google Chrome rendering capabilities, communicates with the locally-installed browser instance using the Puppeteer project, and implements a remote call infrastructure for communication between Node and the browser."
-    },
     "camo":{
       "imports":[
         "camo"
@@ -682,6 +673,15 @@
         "MongoDB"
       ],
       "description":"A class-based ES6 ODM for Mongo-like databases."
+    },
+    "Carlo":{
+      "imports":[
+        "carlo"
+      ],
+      "technologies":[
+        "Desktop applications"
+      ],
+      "description":"Carlo provides Node applications with Google Chrome rendering capabilities, communicates with the locally-installed browser instance using the Puppeteer project, and implements a remote call infrastructure for communication between Node and the browser."
     },
     "Chai":{
       "imports":[
@@ -978,6 +978,26 @@
       ],
       "description":"Production grade React applications that scale. The world's leading companies use Next.js to build server-rendered applications, static websites, and more."
     },
+    "node-mongodb-native":{
+      "imports":[
+        "mongodb"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"The Official MongoDB Node.js Driver"
+    },
+    "node-postgres":{
+      "imports":[
+        "pg"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
+    },
     "NodeJS":{
       "imports":[
         "child_process",
@@ -1008,26 +1028,6 @@
       ],
       "description":"JavaScript runtime built on V8 engine and libuv",
       "image":"https://nodejs.org/static/images/logos/nodejs-new-pantone-black.svg"
-    },
-    "node-mongodb-native":{
-      "imports":[
-        "mongodb"
-      ],
-      "technologies":[
-        "Databases",
-        "MongoDB"
-      ],
-      "description":"The Official MongoDB Node.js Driver"
-    },
-    "node-postgres":{
-      "imports":[
-        "pg"
-      ],
-      "technologies":[
-        "Databases",
-        "PostgreSQL"
-      ],
-      "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
     },
     "NuxtJS":{
       "imports":[
@@ -1158,15 +1158,6 @@
       "description":"Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server.",
       "image":"https://avatars1.githubusercontent.com/u/3591786"
     },
-    "Socket.io":{
-      "imports":[
-        "socket.io"
-      ],
-      "technologies":[
-        "Websockets"
-      ],
-      "description":"Featuring the fastest and most reliable real-time engine."
-    },
     "Slonik":{
       "imports":[
         "slonik"
@@ -1176,6 +1167,15 @@
         "PostgreSQL"
       ],
       "description":"A PostgreSQL client with strict types, detailed logging and assertions."
+    },
+    "Socket.io":{
+      "imports":[
+        "socket.io"
+      ],
+      "technologies":[
+        "Websockets"
+      ],
+      "description":"Featuring the fastest and most reliable real-time engine."
     },
     "Styled Components":{
       "imports":[
@@ -1778,26 +1778,6 @@
       "description":"Angular is an open source web application platform.",
       "image":"https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/angular/angular.png"
     },
-    "pg-promise":{
-      "imports":[
-        "pg-promise"
-      ],
-      "technologies":[
-        "Databases",
-        "PostgreSQL"
-      ],
-      "description":"PostgreSQL interface for Node.js"
-    },
-    "pogi":{
-      "imports":[
-        "pogi"
-      ],
-      "technologies":[
-        "Databases",
-        "PostgreSQL"
-      ],
-      "description":"Javascript library for PostgreSQL and node.js"
-    },
     "mongoose":{
       "imports":[
         "mongoose"
@@ -1847,6 +1827,26 @@
         "PostgreSQL"
       ],
       "description":"node-postgres is a collection of node.js modules for interfacing with your PostgreSQL database."
+    },
+    "pg-promise":{
+      "imports":[
+        "pg-promise"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"PostgreSQL interface for Node.js"
+    },
+    "pogi":{
+      "imports":[
+        "pogi"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"Javascript library for PostgreSQL and node.js"
     },
     "Postgres.js":{
       "imports":[

--- a/libraries.json
+++ b/libraries.json
@@ -1636,6 +1636,16 @@
       "description":"Pandas is a fast, powerful, flexible and easy to use open source data analysis and manipulation tool, built on top of the Python programming language.",
       "image":"https://pandas.pydata.org/static/img/pandas_white.svg"
     },
+    "Psycopg":{
+      "imports":[
+        "psycopg2"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"Psycopg is the most popular PostgreSQL database adapter for the Python programming language."
+    },
     "Pygame":{
       "imports":[
         "pygame"

--- a/libraries.json
+++ b/libraries.json
@@ -842,6 +842,16 @@
       ],
       "description":"MobX is a battle tested library that makes state management simple and scalable by transparently applying functional reactive programming (TFRP)"
     },
+    "mongodb-core":{
+      "imports":[
+        "mongodb-core"
+      ],
+      "technologies":[
+        "Databases",
+        "MongoDB"
+      ],
+      "description":"MongoDB core driver functionality aims to make the smallest viable driver api"
+    },
     "mongoose":{
       "imports":[
         "mongoose"

--- a/libraries.json
+++ b/libraries.json
@@ -1059,6 +1059,16 @@
       ],
       "description":"PostgreSQL interface for Node.js"
     },
+    "pogi":{
+      "imports":[
+        "pogi"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"Javascript library for PostgreSQL and node.js"
+    },
     "Proton Native":{
       "imports":[
         "proton-native"
@@ -1715,6 +1725,16 @@
         "PostgreSQL"
       ],
       "description":"PostgreSQL interface for Node.js"
+    },
+    "pogi":{
+      "imports":[
+        "pogi"
+      ],
+      "technologies":[
+        "Databases",
+        "PostgreSQL"
+      ],
+      "description":"Javascript library for PostgreSQL and node.js"
     },
     "mongoose":{
       "imports":[

--- a/tools/ci-checks.js
+++ b/tools/ci-checks.js
@@ -4,31 +4,38 @@ fs.readFile( __dirname + '/../libraries.json', function (err, data) {
     throw err; 
   }
   data = JSON.parse(data)
-  let previousLibrary = ""
-  for (library in data) {
-    // Check alphabetical order
-    if (library.toLowerCase() < previousLibrary.toLowerCase()) {
-      console.log('ERROR: Libraries are not in alphabetical order. ' + previousLibrary + ' is before ' + library)
-      process.exit(1)
-    }
-    previousLibrary = library
 
-    // Check expected structure
-    if (!Array.isArray(data[library].imports) || data[library].imports.length === 0) {
-      console.log('ERROR: ' + library + '.imports must exist, must be an array and must have at least one element.')
+  let previousLanguage = ""
+  Object.keys(data).forEach(function(language) {
+    // Check alphabetical order of languages
+    if (language.toLowerCase() < previousLanguage.toLowerCase()) {
+      console.log('ERROR: Languages are not in alphabetical order. ' + previousLanguage + ' is before ' + language)
       process.exit(1)
     }
-    if (!Array.isArray(data[library].technologies)  || data[library].technologies.length === 0) {
-      console.log('ERROR: ' + library + '.technologies must exist, must be an array and must have at least one element')
-      process.exit(1)
+    previousLanguage = language
+
+    let previousLibrary = ""
+    for (library in data[language]){
+      // Check alphabetical order of libraries
+      if (library.toLowerCase() < previousLibrary.toLowerCase()) {
+        console.log('ERROR: Libraries are not in alphabetical order. ' + previousLibrary + ' is before ' + library + ' for ' + language)
+        process.exit(1)
+      }
+      previousLibrary = library
+
+      // Check expected structure
+      if (!Array.isArray(data[language][library].imports) || data[language][library].imports.length === 0) {
+        console.log('ERROR: ' + language + '.'  + library + '.imports must exist, must be an array and must have at least one element.')
+        process.exit(1)
+      }
+      if (!Array.isArray(data[language][library].technologies)  || data[language][library].technologies.length === 0) {
+        console.log('ERROR: ' + language + '.'  + library + '.technologies must exist, must be an array and must have at least one element')
+        process.exit(1)
+      }
+      if (typeof data[language][library].description === 'undefined' || data[language][library].description === '') {
+        console.log('ERROR: ' + language + '.' + library + '.description must exist and cannot be empty')
+        process.exit(1)
+      }
     }
-    if (typeof data[library].language === 'undefined' || data[library].language === '') {
-      console.log('ERROR: ' + library + '.language must exist and cannot be empty')
-      process.exit(1)
-    }
-    if (typeof data[library].description === 'undefined' || data[library].description === '') {
-      console.log('ERROR: ' + library + '.description must exist and cannot be empty')
-      process.exit(1)
-    }
-  }
+  })
 });


### PR DESCRIPTION
I added database (MongoDB, MySQL and PostgreSQL) libraries for some languages (JS, TS, Java, Python and PHP). 

However, there are some cases where same name (and sometimes same import style) used for same library, but for different languages. To solve this problem, I grouped libraries by languages. To be able to do that, I changed JSON structure: created a new top level key for language, and removed language from library field. 

I also changed ci-check script according to new JSON structure. 