### PR TITLE
Add gatsby

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -925,6 +925,19 @@
       ],
       "description":"A free and open source framework to develop mobile, desktop or web apps with native look and feel"
     },
+    "Gatsby":{
+      "imports":[
+        "gatsby"
+      ],
+      "technologies":[
+        "Frontend",
+        "Web Development",
+        "SSG",
+        "JavaScript Frameworks"
+      ],
+      "description":"A frameworks for creating static sites.",
+      "image":"https://i.imgur.com/namE7Sp.png"
+    },
     "GraphQL":{
       "imports":[
         "graphql-express",


### PR DESCRIPTION
Add Gatsby, a well-known static site generator, to the JavaScript section.

The official website of Gatsby is <https://www.gatsbyjs.com/>.